### PR TITLE
FEAT Approx. NN search with annoy

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -15,4 +15,5 @@ exclude_lines =
     raise TypeError
     warnings.warn
     only on win32
+    except ImportError
     if __name__ == .__main__.:

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ pip install scikit-hubness
 Dependencies are installed automatically, if necessary.
 `scikit-hubness` requires `numpy`, `scipy` and `scikit-learn`.
 Approximate nearest neighbor search and approximate hubness reduction
-additionally requires `nmslib` and/or `falconn`.
+additionally requires `nmslib`, `falconn`, or `annoy`.
 Some modules require `tqdm` or `joblib`. All these packages are available
 from open repositories, such as [PyPI](https://pypi.org).
 

--- a/requirements-win.txt
+++ b/requirements-win.txt
@@ -5,6 +5,7 @@ pandas
 joblib>=0.12
 tqdm
 nmslib
+annoy
 # falconn  # DOES NOT support Windows
 pytest
 pytest-cov

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ scikit-learn>=0.21
 pandas
 joblib>=0.12
 tqdm
+annoy
 nmslib
 falconn
 pytest

--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,7 @@ setup(
                       'pybind11',  # Required for nmslib build
                       'joblib >= 0.12',
                       'nmslib',
+                      'annoy',
                       'falconn;platform_system!="Windows"',  # falconn is not available on Windows; see also PEP 508
                       ],
     extras_require={  # Install using the 'extras' syntax: $ pip install sampleproject[dev]

--- a/skhubness/neighbors/__init__.py
+++ b/skhubness/neighbors/__init__.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # SPDX-License-Identifier: BSD-3-Clause
-
 """
 The :mod:`skhubness.neighbors` package is a drop-in replacement for :mod:`sklearn.neighbors`,
 providing all of its features, while adding transparent support for hubness reduction
@@ -17,6 +16,7 @@ except (ImportError, ModuleNotFoundError):
     from .approximate_neighbors import UnavailableANN
     LSH = UnavailableANN
 from .kd_tree import KDTree
+from .random_projection_trees import RandomProjectionTree
 from .dist_metrics import DistanceMetric
 from .regression import KNeighborsRegressor, RadiusNeighborsRegressor
 from .nearest_centroid import NearestCentroid
@@ -37,10 +37,12 @@ __all__ = ['BallTree',
            'NearestNeighbors',
            'RadiusNeighborsClassifier',
            'RadiusNeighborsRegressor',
+           'RandomProjectionTree',
            'kneighbors_graph',
            'radius_neighbors_graph',
            'KernelDensity',
            'LocalOutlierFactor',
            'NeighborhoodComponentsAnalysis',
            'VALID_METRICS',
-           'VALID_METRICS_SPARSE']
+           'VALID_METRICS_SPARSE',
+           ]

--- a/skhubness/neighbors/hnsw.py
+++ b/skhubness/neighbors/hnsw.py
@@ -8,6 +8,7 @@ import numpy as np
 from sklearn.utils.validation import check_is_fitted, check_array
 import nmslib
 from .approximate_neighbors import ApproximateNearestNeighbor
+from ..utils.check import check_n_candidates
 
 __all__ = ['HNSW']
 
@@ -65,11 +66,7 @@ class HNSW(ApproximateNearestNeighbor):
         # Check the n_neighbors parameter
         if n_candidates is None:
             n_candidates = self.n_candidates
-        elif n_candidates <= 0:
-            raise ValueError(f"Expected n_neighbors > 0. Got {n_candidates:d}")
-        else:
-            if not np.issubdtype(type(n_candidates), np.integer):
-                raise TypeError(f"n_neighbors does not take {type(n_candidates)} value, enter integer value")
+        n_candidates = check_n_candidates(n_candidates)
 
         # Fetch the neighbor candidates
         neigh_ind_dist = self.index_.knnQueryBatch(X,

--- a/skhubness/neighbors/random_projection_trees.py
+++ b/skhubness/neighbors/random_projection_trees.py
@@ -12,8 +12,8 @@ from typing import Union, Tuple
 try:
     import annoy
 except ImportError:
-    print("The package 'annoy' is required to run this example.")
-    sys.exit()
+    print("The package 'annoy' is required to run this example.")  # pragma: no cover
+    sys.exit()  # pragma: no cover
 
 import numpy as np
 
@@ -106,14 +106,16 @@ class RandomProjectionTree(BaseEstimator, ApproximateNearestNeighbor):
         self.effective_metric_ = metric
         annoy_index = annoy.AnnoyIndex(X.shape[1], metric=metric)
         if self.mmap_dir == 'auto':
-            self.annoy_ = create_tempfile_preferably_in_dir(prefix='skhubness_', suffix='.annoy', dir='/dev/shm')
+            self.annoy_ = create_tempfile_preferably_in_dir(prefix='skhubness_',
+                                                            suffix='.annoy',
+                                                            directory='/dev/shm')
             logging.warning(f'The index will be stored in {self.annoy_}. '
                             f'It will NOT be deleted automatically, when this instance is destructed.')
         elif isinstance(self.mmap_dir, str):
-            self.annoy_ = create_tempfile_preferably_in_dir(prefix='skhubness_', suffix='.annoy', dir=self.mmap_dir)
-        elif self.mmap_dir is None:
-            pass
-        else:
+            self.annoy_ = create_tempfile_preferably_in_dir(prefix='skhubness_',
+                                                            suffix='.annoy',
+                                                            directory=self.mmap_dir)
+        else:  # e.g. None
             self.mmap_dir = None
 
         if self.verbose:

--- a/skhubness/neighbors/random_projection_trees.py
+++ b/skhubness/neighbors/random_projection_trees.py
@@ -1,0 +1,228 @@
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: BSD-3-Clause
+# Author: Tom Dupre la Tour (original work)
+#         Roman Feldbauer (adaptions for scikit-hubness)
+# PEP 563: Postponed Evaluation of Annotations
+from __future__ import annotations
+
+import logging
+import sys
+from typing import Union, Tuple
+
+try:
+    import annoy
+except ImportError:
+    print("The package 'annoy' is required to run this example.")
+    sys.exit()
+
+import numpy as np
+
+from sklearn.base import BaseEstimator
+from sklearn.utils.validation import check_array, check_is_fitted, check_X_y
+from tqdm.auto import tqdm
+from .approximate_neighbors import ApproximateNearestNeighbor
+from ..utils.check import check_n_candidates
+from ..utils.io import create_tempfile_preferably_in_dir
+
+print(__doc__)
+
+__all__ = ['RandomProjectionTree',
+           ]
+
+
+class RandomProjectionTree(BaseEstimator, ApproximateNearestNeighbor):
+    """Wrapper for using annoy.AnnoyIndex
+
+    Parameters
+    ----------
+    n_candidates: int, default = 5
+        Number of neighbors to retrieve
+    metric: str, default = 'euclidean'
+        Distance metric, allowed are "angular", "euclidean", "manhattan", "hamming", "dot"
+    n_trees: int, default = 10
+        Build a forest of n_trees trees. More trees gives higher precision when querying,
+        but are more expensive in terms of build time and index size.
+    search_k: int, default = -1
+        Query will inspect search_k nodes. A larger value will give more accurate results,
+        but will take longer time.
+    mmap_dir: str, default = 'auto'
+        Memory-map the index to the given directory.
+        This is required to make the the class pickleable.
+        If None, keep everything in main memory (NON pickleable index),
+        if mmap_dir is a string, it is interpreted as a directory to store the index into,
+        if 'auto', create a temp dir for the index,
+            preferably in /dev/shm on Linux.
+    n_jobs: int, default = 1
+        Number of parallel jobs
+    verbose: int, default = 0
+        Verbosity level. If verbose > 0, show tqdm progress bar on indexing and querying.
+
+    Attributes
+    ----------
+    valid_metrics:
+        List of valid distance metrics/measures
+    """
+    valid_metrics = ["angular", "euclidean", "manhattan", "hamming", "dot", "minkowski"]
+
+    def __init__(self, n_candidates: int = 5, metric: str = 'euclidean',
+                 n_trees: int = 10, search_k: int = -1, mmap_dir: str = 'auto',
+                 n_jobs: int = 1, verbose: int = 0):
+        super().__init__(n_candidates=n_candidates,
+                         metric=metric,
+                         n_jobs=n_jobs,
+                         verbose=verbose,
+                         )
+        self.n_trees = n_trees
+        self.search_k = search_k
+        self.mmap_dir = mmap_dir
+
+    def fit(self, X, y=None) -> RandomProjectionTree:
+        """ Build the annoy.Index and insert data from X.
+
+        Parameters
+        ----------
+        X: np.array
+            Data to be indexed
+        y: any
+            Ignored
+
+        Returns
+        -------
+        self: RandomProjectionTree
+            An instance of RandomProjectionTree with a built index
+        """
+        if y is None:
+            X = check_array(X)
+        else:
+            X, y = check_X_y(X, y)
+            self.y_train_ = y
+
+        self.n_samples_fit_ = X.shape[0]
+        self.n_features_ = X.shape[1]
+        self.X_dtype_ = X.dtype
+        if self.metric == 'minkowski':  # for compatibility
+            self.metric = 'euclidean'
+        metric = self.metric if self.metric != 'sqeuclidean' else 'euclidean'
+        self.effective_metric_ = metric
+        annoy_index = annoy.AnnoyIndex(X.shape[1], metric=metric)
+        if self.mmap_dir == 'auto':
+            self.annoy_ = create_tempfile_preferably_in_dir(prefix='skhubness_', suffix='.annoy', dir='/dev/shm')
+            logging.warning(f'The index will be stored in {self.annoy_}. '
+                            f'It will NOT be deleted automatically, when this instance is destructed.')
+        elif isinstance(self.mmap_dir, str):
+            self.annoy_ = create_tempfile_preferably_in_dir(prefix='skhubness_', suffix='.annoy', dir=self.mmap_dir)
+        elif self.mmap_dir is None:
+            pass
+        else:
+            self.mmap_dir = None
+
+        if self.verbose:
+            enumerate_X = tqdm(enumerate(X),
+                               desc='Build RPtree',
+                               total=len(X),
+                               )
+        else:
+            enumerate_X = enumerate(X)
+        for i, x in enumerate_X:
+            annoy_index.add_item(i, x.tolist())
+        annoy_index.build(self.n_trees)
+
+        if self.mmap_dir is None:
+            self.annoy_ = annoy_index
+        else:
+            annoy_index.save(self.annoy_, )
+
+        return self
+
+    def kneighbors(self, X=None, n_candidates=None, return_distance=True) -> Union[Tuple[np.array, np.array], np.array]:
+        """ Retrieve k nearest neighbors.
+
+        Parameters
+        ----------
+        X: np.array or None, optional, default = None
+            Query objects. If None, search among the indexed objects.
+        n_candidates: int or None, optional, default = None
+            Number of neighbors to retrieve.
+            If None, use the value passed during construction.
+        return_distance: bool, default = True
+            If return_distance, will return distances and indices to neighbors.
+            Else, only return the indices.
+        """
+        check_is_fitted(self, 'annoy_')
+        if X is not None:
+            X = check_array(X)
+
+        n_test = self.n_samples_fit_ if X is None else X.shape[0]
+        dtype = self.X_dtype_ if X is None else X.dtype
+
+        if n_candidates is None:
+            n_candidates = self.n_candidates
+        n_candidates = check_n_candidates(n_candidates)
+
+        # For compatibility reasons, as each sample is considered as its own
+        # neighbor, one extra neighbor will be computed.
+        if X is None:
+            n_neighbors = n_candidates + 1
+            start = 1
+        else:
+            n_neighbors = n_candidates
+            start = 0
+
+        # If fewer candidates than required are found for a query,
+        # we save index=-1 and distance=NaN
+        neigh_ind = -np.ones((n_test, n_candidates),
+                             dtype=np.int32)
+        neigh_dist = np.empty_like(neigh_ind,
+                                   dtype=dtype) * np.nan
+
+        # Load memory-mapped annoy.Index, unless it's already in main memory
+        if isinstance(self.annoy_, str):
+            annoy_index = annoy.AnnoyIndex(self.n_features_, metric=self.effective_metric_)
+            annoy_index.load(self.annoy_)
+        elif isinstance(self.annoy_, annoy.AnnoyIndex):
+            annoy_index = self.annoy_
+        assert isinstance(annoy_index, annoy.AnnoyIndex), f'Internal error: unexpected type for annoy index'
+
+        if X is None:
+            if self.verbose:
+                n_items = annoy_index.get_n_items()
+                query_ind = tqdm(range(n_items),
+                                 desc='Query RPtree',
+                                 total=n_items,
+                                 )
+            else:
+                query_ind = range(annoy_index.get_n_items())
+            for i in query_ind:
+                ind, dist = annoy_index.get_nns_by_item(
+                    i, n_neighbors, self.search_k,
+                    include_distances=True,
+                )
+                ind = ind[start:]
+                dist = dist[start:]
+                neigh_ind[i, :len(ind)] = ind
+                neigh_dist[i, :len(dist)] = dist
+        else:  # if X was provided
+            if self.verbose:
+                enumerate_X = tqdm(enumerate(X),
+                                   desc='Query RPtree',
+                                   total=len(X),
+                                   )
+            else:
+                enumerate_X = enumerate(X)
+            for i, x in enumerate_X:
+                ind, dist = annoy_index.get_nns_by_vector(
+                    x.tolist(), n_neighbors, self.search_k,
+                    include_distances=True,
+                )
+                ind = ind[start:]
+                dist = dist[start:]
+                neigh_ind[i, :len(ind)] = ind
+                neigh_dist[i, :len(dist)] = dist
+
+        if self.metric == 'sqeuclidean':
+            neigh_dist **= 2
+
+        if return_distance:
+            return neigh_dist, neigh_ind
+        else:
+            return neigh_ind

--- a/skhubness/neighbors/tests/test_pgtree.py
+++ b/skhubness/neighbors/tests/test_pgtree.py
@@ -1,0 +1,141 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+import pytest
+import numpy as np
+from sklearn.datasets import make_classification
+from sklearn.utils.estimator_checks import check_estimator
+from sklearn.utils.testing import assert_array_equal, assert_array_almost_equal
+from sklearn.utils.testing import assert_raises
+from skhubness.neighbors import RandomProjectionTree, NearestNeighbors
+
+
+@pytest.mark.parametrize('n_candidates', [1, 2, 5, 99, 100, 1000, ])
+@pytest.mark.parametrize('set_in_constructor', [True, False])
+@pytest.mark.parametrize('return_distance', [True, False])
+@pytest.mark.parametrize('search_among_indexed', [True, False])
+def test_return_correct_number_of_neighbors(n_candidates: int,
+                                            set_in_constructor: bool,
+                                            return_distance: bool,
+                                            search_among_indexed: bool):
+    n_samples = 100
+    X, y = make_classification(n_samples=n_samples)
+    ann = RandomProjectionTree(n_candidates=n_candidates) if set_in_constructor else RandomProjectionTree()
+    ann.fit(X, y)
+    X_query = None if search_among_indexed else X
+    neigh = ann.kneighbors(X_query, return_distance=return_distance) if set_in_constructor\
+        else ann.kneighbors(X_query, n_candidates=n_candidates, return_distance=return_distance)
+
+    if return_distance:
+        dist, neigh = neigh
+        assert dist.shape == neigh.shape, f'Shape of distances and indices matrices do not match.'
+        if n_candidates > n_samples:
+            assert np.all(np.isnan(dist[:, n_samples:])), f'Returned distances for invalid neighbors'
+
+    assert neigh.shape[1] == n_candidates, f'Wrong number of neighbors returned.'
+    if n_candidates > n_samples:
+        assert np.all(neigh[:, n_samples:] == -1), f'Returned indices for invalid neighbors'
+
+
+@pytest.mark.parametrize('metric', ['invalid', None])
+def test_invalid_metric(metric):
+    X, y = make_classification(n_samples=10, n_features=10)
+    ann = RandomProjectionTree(metric=metric)
+    with assert_raises(Exception):  # annoy raises ValueError or TypeError
+        _ = ann.fit(X, y)
+
+
+@pytest.mark.parametrize('metric', RandomProjectionTree.valid_metrics)
+@pytest.mark.parametrize('n_jobs', [-1, 1, None])
+@pytest.mark.parametrize('verbose', [0, 1])
+def test_kneighbors_with_or_without_distances(metric, n_jobs, verbose):
+    n_samples = 100
+    X, y = make_classification(n_samples=n_samples,
+                               random_state=123,
+                               )
+    ann = RandomProjectionTree(metric=metric,
+                               n_jobs=n_jobs,
+                               verbose=verbose,
+                               )
+    ann.fit(X, y)
+    neigh_dist_self, neigh_ind_self = ann.kneighbors(X, return_distance=True)
+    ind_only_self = ann.kneighbors(X, return_distance=False)
+
+    # Identical neighbors retrieved, whether dist or not
+    assert_array_equal(neigh_ind_self, ind_only_self)
+
+    # Is the first hit always the object itself?
+    # Less strict test for dot/hamming distances
+    if metric in ['dot']:
+        assert np.setdiff1d(neigh_ind_self[:, 0], np.arange(len(neigh_ind_self))).size <= n_samples // 10
+    elif metric in ['hamming']:
+        assert np.setdiff1d(neigh_ind_self[:, 0], np.arange(len(neigh_ind_self))).size <= n_samples // 100
+    else:
+        assert_array_equal(neigh_ind_self[:, 0], np.arange(len(neigh_ind_self)))
+
+    if metric in ['dot']:
+        pass  # does not guarantee self distance 0
+    else:  # distances in [0, inf]
+        assert_array_almost_equal(neigh_dist_self[:, 0], np.zeros(len(neigh_dist_self)))
+
+
+@pytest.mark.parametrize('metric', RandomProjectionTree.valid_metrics)
+def test_kneighbors_with_or_without_self_hit(metric):
+    X, y = make_classification(random_state=1234435)
+    n_candidates = 5
+    ann = RandomProjectionTree(metric=metric,
+                               n_candidates=n_candidates,
+                               )
+    ann.fit(X, y)
+    ind_self = ann.kneighbors(X, n_candidates=n_candidates+1, return_distance=False)
+    ind_no_self = ann.kneighbors(n_candidates=n_candidates, return_distance=False)
+
+    if metric in ['dot']:  # dot is just inaccurate...
+        assert (ind_self[:, 0] == np.arange(len(ind_self))).sum() > 92
+        assert np.setdiff1d(ind_self[:, 1:], ind_no_self).size <= 10
+    else:
+        assert_array_equal(ind_self[:, 0], np.arange(len(ind_self)))
+        assert_array_equal(ind_self[:, 1:], ind_no_self)
+
+
+def test_squared_euclidean_same_neighbors_as_euclidean():
+    X, y = make_classification()
+    ann = RandomProjectionTree(metric='euclidean')
+    ann.fit(X, y)
+    neigh_dist_eucl, neigh_ind_eucl = ann.kneighbors(X)
+
+    ann = RandomProjectionTree(metric='sqeuclidean')
+    ann.fit(X, y)
+    neigh_dist_sqeucl, neigh_ind_sqeucl = ann.kneighbors(X)
+
+    assert_array_equal(neigh_ind_eucl, neigh_ind_sqeucl)
+    assert_array_almost_equal(neigh_dist_eucl ** 2, neigh_dist_sqeucl)
+
+
+def test_same_neighbors_as_with_exact_nn_search():
+    X = np.random.RandomState(42).randn(10, 2)
+
+    nn = NearestNeighbors()
+    nn_dist, nn_neigh = nn.fit(X).kneighbors(return_distance=True)
+
+    ann = RandomProjectionTree()
+    ann_dist, ann_neigh = ann.fit(X).kneighbors(return_distance=True)
+
+    assert_array_almost_equal(ann_dist, nn_dist, decimal=5)
+    assert_array_almost_equal(ann_neigh, nn_neigh, decimal=0)
+
+
+def test_is_valid_estimator():
+    check_estimator(RandomProjectionTree)
+
+
+@pytest.mark.parametrize('mmap_dir', [None, 'auto', '/dev/shm', '/tmp'])
+def test_memory_mapped(mmap_dir):
+    X, y = make_classification(n_samples=10,
+                               n_features=5,
+                               random_state=123,
+                               )
+    ann = RandomProjectionTree(mmap_dir=mmap_dir)
+    ann.fit(X, y)
+    _ = ann.kneighbors(X)
+    _ = ann.kneighbors()
+

--- a/skhubness/neighbors/tests/test_rptree.py
+++ b/skhubness/neighbors/tests/test_rptree.py
@@ -13,13 +13,16 @@ from skhubness.neighbors import RandomProjectionTree, NearestNeighbors
 @pytest.mark.parametrize('set_in_constructor', [True, False])
 @pytest.mark.parametrize('return_distance', [True, False])
 @pytest.mark.parametrize('search_among_indexed', [True, False])
+@pytest.mark.parametrize('verbose', [True, False])
 def test_return_correct_number_of_neighbors(n_candidates: int,
                                             set_in_constructor: bool,
                                             return_distance: bool,
-                                            search_among_indexed: bool):
+                                            search_among_indexed: bool,
+                                            verbose: bool):
     n_samples = 100
     X, y = make_classification(n_samples=n_samples)
-    ann = RandomProjectionTree(n_candidates=n_candidates) if set_in_constructor else RandomProjectionTree()
+    ann = RandomProjectionTree(n_candidates=n_candidates, verbose=verbose)\
+        if set_in_constructor else RandomProjectionTree(verbose=verbose)
     ann.fit(X, y)
     X_query = None if search_among_indexed else X
     neigh = ann.kneighbors(X_query, return_distance=return_distance) if set_in_constructor\

--- a/skhubness/neighbors/tests/test_rptree.py
+++ b/skhubness/neighbors/tests/test_rptree.py
@@ -72,7 +72,7 @@ def test_kneighbors_with_or_without_distances(metric, n_jobs, verbose):
     else:
         assert_array_equal(neigh_ind_self[:, 0], np.arange(len(neigh_ind_self)))
 
-    if metric in ['dot']:
+    if metric in ['dot', 'angular']:
         pass  # does not guarantee self distance 0
     else:  # distances in [0, inf]
         assert_array_almost_equal(neigh_dist_self[:, 0], np.zeros(len(neigh_dist_self)))

--- a/skhubness/utils/check.py
+++ b/skhubness/utils/check.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: BSD-3-Clause
+# Author: Roman Feldbauer
+
+import numpy as np
+
+
+def check_n_candidates(n_candidates):
+    # Check the n_neighbors parameter
+    if n_candidates <= 0:
+        raise ValueError(f"Expected n_neighbors > 0. Got {n_candidates:d}")
+    if not np.issubdtype(type(n_candidates), np.integer):
+        raise TypeError(f"n_neighbors does not take {type(n_candidates)} value, enter integer value")
+    return n_candidates

--- a/skhubness/utils/check.py
+++ b/skhubness/utils/check.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 # SPDX-License-Identifier: BSD-3-Clause
 # Author: Roman Feldbauer
-
 import numpy as np
+
+__all__ = ['check_n_candidates']
 
 
 def check_n_candidates(n_candidates):

--- a/skhubness/utils/io.py
+++ b/skhubness/utils/io.py
@@ -1,0 +1,20 @@
+from logging import warning
+from tempfile import mkstemp, NamedTemporaryFile
+
+
+def create_tempfile_preferably_in_dir(suffix=None, prefix=None, dir=None, text=False, persistant: bool = False, ):
+    """ Create a temporary file with precedence for dir if possible, in TMP otherwise.
+    For example, this is useful to try to save into /dev/shm.
+    """
+    temp_file = mkstemp if persistant else NamedTemporaryFile
+    try:
+        handle = temp_file(suffix=suffix, prefix=prefix, dir=dir)
+    except FileNotFoundError:
+        handle = temp_file(suffix=suffix, prefix=prefix, dir=None)
+        warning(f'Could not create temp file in {dir}. '
+                f'Instead, the path is {handle}.')
+    try:
+        path = handle.name
+    except AttributeError:
+        _, path = handle
+    return path

--- a/skhubness/utils/io.py
+++ b/skhubness/utils/io.py
@@ -1,17 +1,22 @@
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: BSD-3-Clause
+# Author: Roman Feldbauer
 from logging import warning
 from tempfile import mkstemp, NamedTemporaryFile
 
+__all__ = ['create_tempfile_preferably_in_dir']
 
-def create_tempfile_preferably_in_dir(suffix=None, prefix=None, dir=None, text=False, persistant: bool = False, ):
-    """ Create a temporary file with precedence for dir if possible, in TMP otherwise.
+
+def create_tempfile_preferably_in_dir(suffix=None, prefix=None, directory=None, persistent: bool = False, ):
+    """ Create a temporary file with precedence for directory if possible, in TMP otherwise.
     For example, this is useful to try to save into /dev/shm.
     """
-    temp_file = mkstemp if persistant else NamedTemporaryFile
+    temp_file = mkstemp if persistent else NamedTemporaryFile
     try:
-        handle = temp_file(suffix=suffix, prefix=prefix, dir=dir)
+        handle = temp_file(suffix=suffix, prefix=prefix, dir=directory)
     except FileNotFoundError:
         handle = temp_file(suffix=suffix, prefix=prefix, dir=None)
-        warning(f'Could not create temp file in {dir}. '
+        warning(f'Could not create temp file in {directory}. '
                 f'Instead, the path is {handle}.')
     try:
         path = handle.name

--- a/skhubness/utils/tests/test_io.py
+++ b/skhubness/utils/tests/test_io.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Author: Roman Feldbauer
 import os
+import platform
 import pytest
 from skhubness.utils.io import create_tempfile_preferably_in_dir
 
@@ -10,5 +11,5 @@ from skhubness.utils.io import create_tempfile_preferably_in_dir
 def test_tempfile(persistent):
     f = create_tempfile_preferably_in_dir(persistent=persistent)
     assert isinstance(f, str)
-    if persistent:
+    if persistent and platform.system() != 'Windows':  # locked by running process on Windows
         os.remove(f)

--- a/skhubness/utils/tests/test_io.py
+++ b/skhubness/utils/tests/test_io.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: BSD-3-Clause
+# Author: Roman Feldbauer
+import os
+import pytest
+from skhubness.utils.io import create_tempfile_preferably_in_dir
+
+
+@pytest.mark.parametrize('persistent', [True, False])
+def test_tempfile(persistent):
+    f = create_tempfile_preferably_in_dir(persistent=persistent)
+    assert isinstance(f, str)
+    if persistent:
+        os.remove(f)


### PR DESCRIPTION
Let's introduce another approximate nearest neighbor methods: random projection trees, provided by the `annoy` library. 

This faces the same problem as mentioned in issue #20 but solves it by memmapping the `annoy.Index` to a temporary file, preferably in /dev/shm.