### PR TITLE
Puffinn LSH

### DIFF
--- a/docs/documentation.rst
+++ b/docs/documentation.rst
@@ -43,7 +43,7 @@ Neighbors: :mod:`skhubness.neighbors`
    neighbors.HNSW
    neighbors.KNeighborsClassifier
    neighbors.KNeighborsRegressor
-   neighbors.LSH
+   neighbors.FalconnLSH
    neighbors.NearestCentroid
    neighbors.NearestNeighbors
    neighbors.RadiusNeighborsClassifier

--- a/skhubness/analysis/estimation.py
+++ b/skhubness/analysis/estimation.py
@@ -79,7 +79,7 @@ class Hubness(BaseEstimator):
         Algorithm used to compute the nearest neighbors:
 
         - 'hnsw' will use :class:`HNSW`
-        - 'lsh' will use :class:`LSH`
+        - 'lsh' will use :class:`FalconnLSH`
         - 'ball_tree' will use :class:`BallTree`
         - 'kd_tree' will use :class:`KDTree`
         - 'brute' will use a brute-force search.

--- a/skhubness/neighbors/__init__.py
+++ b/skhubness/neighbors/__init__.py
@@ -10,11 +10,15 @@ from .base import VALID_METRICS, VALID_METRICS_SPARSE
 from .classification import KNeighborsClassifier, RadiusNeighborsClassifier
 from .graph import kneighbors_graph, radius_neighbors_graph
 from .hnsw import HNSW
+from .approximate_neighbors import UnavailableANN
 try:
-    from .lsh import LSH
+    from .lsh import FalconnLSH
 except (ImportError, ModuleNotFoundError):
-    from .approximate_neighbors import UnavailableANN
-    LSH = UnavailableANN
+    FalconnLSH = UnavailableANN
+try:
+    from .lsh import PuffinnLSH
+except ImportError:
+    PuffinnLSH = UnavailableANN
 from .kd_tree import KDTree
 from .random_projection_trees import RandomProjectionTree
 from .dist_metrics import DistanceMetric
@@ -28,13 +32,14 @@ from .unsupervised import NearestNeighbors
 
 __all__ = ['BallTree',
            'DistanceMetric',
+           'FalconnLSH',
            'KDTree',
            'HNSW',
            'KNeighborsClassifier',
            'KNeighborsRegressor',
-           'LSH',
            'NearestCentroid',
            'NearestNeighbors',
+           'PuffinnLSH',
            'RadiusNeighborsClassifier',
            'RadiusNeighborsRegressor',
            'RandomProjectionTree',

--- a/skhubness/neighbors/base.py
+++ b/skhubness/neighbors/base.py
@@ -471,7 +471,10 @@ class NeighborsBase(SklearnNeighborsBase):
         check_is_fitted(self, "_fit_method")
 
         if n_neighbors is None:
-            n_neighbors = self.algorithm_params['n_candidates']
+            try:
+                n_neighbors = self.algorithm_params['n_candidates']
+            except KeyError:
+                n_neighbors = 1 if self.hubness is None else 100
         elif n_neighbors <= 0:
             raise ValueError(f"Expected n_neighbors > 0. Got {n_neighbors}")
         else:

--- a/skhubness/neighbors/classification.py
+++ b/skhubness/neighbors/classification.py
@@ -52,7 +52,8 @@ class KNeighborsClassifier(NeighborsBase, KNeighborsMixin,
         Algorithm used to compute the nearest neighbors:
 
         - 'hnsw' will use :class:`HNSW`
-        - 'lsh' will use :class:`LSH`
+        - 'lsh' will use :class:`PuffinnLSH`
+        - 'falconn_lsh' will use :class:`FalconnLSH`
         - 'ball_tree' will use :class:`BallTree`
         - 'kd_tree' will use :class:`KDTree`
         - 'brute' will use a brute-force search.
@@ -290,9 +291,10 @@ class RadiusNeighborsClassifier(NeighborsBase, RadiusNeighborsMixin,
 
         Uniform weights are used by default.
 
-    algorithm: {'auto', 'ball_tree', 'kd_tree', 'brute'}, optional
+    algorithm: {'auto', 'falconn_lsh', 'ball_tree', 'kd_tree', 'brute'}, optional
         Algorithm used to compute the nearest neighbors:
 
+        - 'falconn_lsh' will use :class:`FalconnLSH`
         - 'ball_tree' will use :class:`BallTree`
         - 'kd_tree' will use :class:`KDTree`
         - 'brute' will use a brute-force search.

--- a/skhubness/neighbors/graph.py
+++ b/skhubness/neighbors/graph.py
@@ -58,11 +58,12 @@ def kneighbors_graph(X, n_neighbors, mode='connectivity',
         matrix with ones and zeros, and 'distance' will return the distances
         between neighbors according to the given metric.
 
-    algorithm: {'auto', 'hnsw', 'lsh', 'ball_tree', 'kd_tree', 'brute'}, optional
+    algorithm: {'auto', 'hnsw', 'lsh', 'falconn_lsh', 'ball_tree', 'kd_tree', 'brute'}, optional
         Algorithm used to compute the nearest neighbors:
 
         - 'hnsw' will use :class:`HNSW`
-        - 'lsh' will use :class:`LSH`
+        - 'lsh' will use :class:`PuffinnLSH`
+        - 'falconn_lsh' will use :class:`FalconnLSH`
         - 'ball_tree' will use :class:`BallTree`
         - 'kd_tree' will use :class:`KDTree`
         - 'brute' will use a brute-force search.
@@ -183,11 +184,11 @@ def radius_neighbors_graph(X, radius, mode='connectivity',
         matrix with ones and zeros, and 'distance' will return the distances
         between neighbors according to the given metric.
 
-    algorithm: {'auto', 'hnsw', 'lsh', 'ball_tree', 'kd_tree', 'brute'}, optional
+    algorithm: {'auto', 'hnsw', 'falconn_lsh', 'ball_tree', 'kd_tree', 'brute'}, optional
         Algorithm used to compute the nearest neighbors:
 
         - 'hnsw' will use :class:`HNSW`
-        - 'lsh' will use :class:`LSH`
+        - 'falconn_lsh' will use :class:`FalconnLSH`
         - 'ball_tree' will use :class:`BallTree`
         - 'kd_tree' will use :class:`KDTree`
         - 'brute' will use a brute-force search.

--- a/skhubness/neighbors/lof.py
+++ b/skhubness/neighbors/lof.py
@@ -42,11 +42,12 @@ class LocalOutlierFactor(NeighborsBase, KNeighborsMixin, UnsupervisedMixin,
         If n_neighbors is larger than the number of samples provided,
         all samples will be used.
 
-    algorithm : {'auto', 'hnsw', 'lsh', 'ball_tree', 'kd_tree', 'brute'}, optional
+    algorithm : {'auto', 'hnsw', 'lsh', 'falconn_lsh', 'ball_tree', 'kd_tree', 'brute'}, optional
         Algorithm used to compute the nearest neighbors:
 
         - 'hnsw' will use :class:`HNSW`
-        - 'lsh' will use :class:`LSH`
+        - 'lsh' will use :class:`PuffinnLSH`
+        - 'falconn_lsh' will use :class:`FalconnLSH`
         - 'ball_tree' will use :class:`BallTree`
         - 'kd_tree' will use :class:`KDTree`
         - 'brute' will use a brute-force search.

--- a/skhubness/neighbors/lsh.py
+++ b/skhubness/neighbors/lsh.py
@@ -5,20 +5,202 @@
 from __future__ import annotations
 
 from functools import partial
+import logging
 from typing import Tuple, Union
 import warnings
 import numpy as np
-from sklearn.metrics import euclidean_distances
+from sklearn.base import BaseEstimator
+from sklearn.metrics import euclidean_distances, pairwise_distances
 from sklearn.metrics.pairwise import cosine_distances
-from sklearn.utils.validation import check_is_fitted, check_array
-import falconn
+from sklearn.utils.validation import check_is_fitted, check_array, check_X_y
+try:
+    import falconn
+except ImportError:
+    logging.warning("The package 'falconn' is not available.")  # pragma: no cover
+try:
+    import puffinn
+except (ImportError, ModuleNotFoundError) as e:
+    logging.warning("The package 'puffinn' is not available.")  # pragma: no cover
 from tqdm.auto import tqdm
-
 from .approximate_neighbors import ApproximateNearestNeighbor
-__all__ = ['LSH']
+from ..utils.check import check_n_candidates
+
+__all__ = ['FalconnLSH', 'PuffinnLSH', ]
 
 
-class LSH(ApproximateNearestNeighbor):
+class PuffinnLSH(BaseEstimator, ApproximateNearestNeighbor):
+    """ Wrap Puffinn LSH for scikit-learn compatibility.
+
+    Parameters
+    ----------
+    n_candidates: int, default = 5
+        Number of neighbors to retrieve
+    metric: str, default = 'angular'
+        Distance metric, allowed are "angular", "jaccard".
+        Other metrics are partially supported, such as 'euclidean', 'sqeuclidean'.
+        In these cases, 'angular' distances are used to find the candidate set
+        of neighbors with LSH among all indexed objects, and (squared) Euclidean
+        distances are subsequently only computed for the candidates.
+    memory: int, default = 1GB
+        Max memory usage
+    recall: float, default = 0.80
+        Probability of finding the true nearest neighbors among the candidates
+    n_jobs: int, default = 1
+        Number of parallel jobs
+    verbose: int, default = 0
+        Verbosity level. If verbose > 0, show tqdm progress bar on indexing and querying.
+
+    Attributes
+    ----------
+    valid_metrics:
+        List of valid distance metrics/measures
+    """
+    valid_metrics = ["angular", "cosine", "euclidean", "sqeuclidean", "minkowski",
+                     "jaccard",
+                     ]
+    candidate_metric = {'euclidean': 'angular',
+                        'sqeulidean': 'angular',
+                        'minkowski': 'angular',
+                        'cosine': 'angular',
+                        }
+
+    def __init__(self, n_candidates: int = 5,
+                 metric: str = 'angular',
+                 memory: int = 1*(1024**3),
+                 recall: float = 0.8,
+                 n_jobs: int = 1,
+                 verbose: int = 0,
+                 ):
+        super().__init__(n_candidates=n_candidates,
+                         metric=metric,
+                         n_jobs=n_jobs,
+                         verbose=verbose,
+                         )
+        self.memory = memory
+        self.recall = recall
+
+    def fit(self, X, y=None) -> PuffinnLSH:
+        """ Build the puffinn LSH index and insert data from X.
+
+        Parameters
+        ----------
+        X: np.array
+            Data to be indexed
+        y: any
+            Ignored
+
+        Returns
+        -------
+        self: Puffinn
+            An instance of Puffinn with a built index
+        """
+        if y is None:
+            X = check_array(X)
+        else:
+            X, y = check_X_y(X, y)
+            self.y_train_ = y
+
+        if self.metric in self.valid_metrics:
+            self.filter_metric = self.candidate_metric[self.metric]
+        else:
+            self.filter_metric = self.metric
+
+        # Construct the index
+        index = puffinn.Index(self.filter_metric,
+                              X.shape[1],
+                              self.memory,
+                              )
+
+        if self.verbose:
+            iter_X = tqdm(X, desc='Indexing', total=len(X))
+        else:
+            iter_X = X
+        for v in iter_X:
+            index.insert(v.tolist())
+        index.rebuild()
+
+        self.index_ = index
+        self.X_train_ = X  # remove, once we can retrieve vectors from the index itself
+
+        return self
+
+    def kneighbors(self, X=None, n_candidates=None, return_distance=True) -> Union[Tuple[np.array, np.array], np.array]:
+        """ Retrieve k nearest neighbors.
+
+        Parameters
+        ----------
+        X: np.array or None, optional, default = None
+            Query objects. If None, search among the indexed objects.
+        n_candidates: int or None, optional, default = None
+            Number of neighbors to retrieve.
+            If None, use the value passed during construction.
+        return_distance: bool, default = True
+            If return_distance, will return distances and indices to neighbors.
+            Else, only return the indices.
+        """
+        check_is_fitted(self, 'index_')
+        if X is not None:
+            X = check_array(X)
+        else:
+            X = self.X_train_
+
+        n_test = X.shape[0]
+        dtype = X.dtype
+
+        if n_candidates is None:
+            n_candidates = self.n_candidates
+        n_candidates = check_n_candidates(n_candidates)
+
+        # For compatibility reasons, as each sample is considered as its own
+        # neighbor, one extra neighbor will be computed.
+        if X is None:
+            n_neighbors = n_candidates + 1
+            start = 1
+        else:
+            n_neighbors = n_candidates
+            start = 0
+
+        # If fewer candidates than required are found for a query,
+        # we save index=-1 and distance=NaN
+        neigh_ind = -np.ones((n_test, n_candidates),
+                             dtype=np.int32)
+        if return_distance:
+            neigh_dist = np.empty_like(neigh_ind,
+                                       dtype=dtype) * np.nan
+            metric = 'cosine' if self.metric == 'angular' else self.metric
+
+        index = self.index_
+
+        if self.verbose:
+            enumerate_X = tqdm(enumerate(X),
+                               desc='Querying',
+                               total=n_test,
+                               )
+        else:
+            enumerate_X = enumerate(X)
+        for i, x in enumerate_X:
+            # Find the approximate nearest neighbors.
+            # Each of the true `n_candidates` nearest neighbors
+            # has at least `recall` chance of being found.
+            ind = index.search(x.tolist(),
+                               n_neighbors,
+                               self.recall,
+                               )
+
+            ind = ind[start:]
+            neigh_ind[i, :len(ind)] = ind
+            if return_distance:
+                neigh_dist[i, :len(ind)] = pairwise_distances(x, self.X_train_[ind],
+                                                              metric=metric,
+                                                              )
+
+        if return_distance:
+            return neigh_dist, neigh_ind
+        else:
+            return neigh_ind
+
+
+class FalconnLSH(ApproximateNearestNeighbor):
     """Wrapper for using falconn LSH
 
     Falconn is an approximate nearest neighbor library,
@@ -65,7 +247,7 @@ class LSH(ApproximateNearestNeighbor):
         self.num_probes = num_probes
         self.radius = radius
 
-    def fit(self, X: np.ndarray, y: np.ndarray = None) -> LSH:
+    def fit(self, X: np.ndarray, y: np.ndarray = None) -> FalconnLSH:
         """ Setup the LSH index from training data.
 
         Parameters
@@ -77,7 +259,7 @@ class LSH(ApproximateNearestNeighbor):
 
         Returns
         -------
-        self: LSH
+        self: FalconnLSH
             An instance of LSH with a built index
         """
         X = check_array(X, dtype=[np.float32, np.float64])

--- a/skhubness/neighbors/regression.py
+++ b/skhubness/neighbors/regression.py
@@ -54,11 +54,12 @@ class KNeighborsRegressor(NeighborsBase, KNeighborsMixin,
 
         Uniform weights are used by default.
 
-    algorithm: {'auto', 'hnsw', 'lsh', 'ball_tree', 'kd_tree', 'brute'}, optional
+    algorithm: {'auto', 'hnsw', 'lsh', 'falconn_lsh', 'ball_tree', 'kd_tree', 'brute'}, optional
         Algorithm used to compute the nearest neighbors:
 
         - 'hnsw' will use :class:`HNSW`
-        - 'lsh' will use :class:`LSH`
+        - 'lsh' will use :class:`PuffinnLSH`
+        - 'falconn_lsh' will use :class:`FalconnLSH`
         - 'ball_tree' will use :class:`BallTree`
         - 'kd_tree' will use :class:`KDTree`
         - 'brute' will use a brute-force search.
@@ -244,11 +245,11 @@ class RadiusNeighborsRegressor(NeighborsBase, RadiusNeighborsMixin,
 
         Uniform weights are used by default.
 
-    algorithm: {'auto', 'hnsw', 'lsh', 'ball_tree', 'kd_tree', 'brute'}, optional
+    algorithm: {'auto', 'hnsw', 'falconn_lsh', 'ball_tree', 'kd_tree', 'brute'}, optional
         Algorithm used to compute the nearest neighbors:
 
         - 'hnsw' will use :class:`HNSW`
-        - 'lsh' will use :class:`LSH`
+        - 'falconn_lsh' will use :class:`FalconnLSH`
         - 'ball_tree' will use :class:`BallTree`
         - 'kd_tree' will use :class:`KDTree`
         - 'brute' will use a brute-force search.

--- a/skhubness/neighbors/tests/test_lof.py
+++ b/skhubness/neighbors/tests/test_lof.py
@@ -40,10 +40,13 @@ EXACT_ALGORITHMS = ('ball_tree',
 # lsh uses FALCONN, which does not support Windows
 if sys.platform == 'win32':  # pragma: no cover
     APPROXIMATE_ALGORITHMS = ('hnsw',  # pragma: no cover
+                              'rptree',
                               )
 else:
     APPROXIMATE_ALGORITHMS = ('lsh',
+                              'falconn_lsh',
                               'hnsw',
+                              'rptree',
                               )
 HUBNESS_ALGORITHMS = ('mp',
                       'ls',

--- a/skhubness/neighbors/tests/test_lsh.py
+++ b/skhubness/neighbors/tests/test_lsh.py
@@ -2,21 +2,28 @@
 
 import pytest
 import sys
+import numpy as np
 from sklearn.datasets import make_classification
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_array_equal
 from skhubness.neighbors import FalconnLSH, PuffinnLSH
 
+# Exclude libraries that are not available on specific platforms
+if sys.platform == 'win32':
+    LSH_METHODS = (PuffinnLSH, )
+    LSH_WITH_RADIUS = ()
+else:
+    LSH_METHODS = (FalconnLSH, PuffinnLSH, )
+    LSH_WITH_RADIUS = (FalconnLSH, )
 
-@pytest.mark.parametrize('LSH', [FalconnLSH, ])
+
+@pytest.mark.parametrize('LSH', LSH_METHODS)
 @pytest.mark.parametrize('metric', ['euclidean', 'cosine'])
 @pytest.mark.parametrize('n_jobs', [-1, 1, None])
 @pytest.mark.parametrize('verbose', [0, 1])
-def test_kneighbors_with_or_without_self_hit(LSH, metric, n_jobs, verbose):
-    if sys.platform == 'win32' and issubclass(LSH, FalconnLSH):
-        pytest.skip('The falconn package is not available for Windows.')
-    X, y = make_classification()
-    lsh = FalconnLSH(metric=metric, n_jobs=n_jobs, verbose=verbose)
+def test_kneighbors_with_or_without_self_hit(LSH: callable, metric, n_jobs, verbose):
+    X, y = make_classification(random_state=234)
+    lsh = LSH(metric=metric, n_jobs=n_jobs, verbose=verbose)
     lsh.fit(X, y)
     neigh_dist, neigh_ind = lsh.kneighbors(return_distance=True)
     neigh_dist_self, neigh_ind_self = lsh.kneighbors(X, return_distance=True)
@@ -24,22 +31,30 @@ def test_kneighbors_with_or_without_self_hit(LSH, metric, n_jobs, verbose):
     ind_only = lsh.kneighbors(return_distance=False)
     ind_only_self = lsh.kneighbors(X, return_distance=False)
 
-    assert_array_equal(neigh_ind, ind_only)
-    assert_array_equal(neigh_ind_self, ind_only_self)
+    if issubclass(LSH, PuffinnLSH):
+        # There appears to be random fluctuations in puffinn...
+        assert (neigh_ind == ind_only).mean() >= 0.95
+        assert (neigh_ind_self == ind_only_self).mean() >= 0.95
 
-    assert_array_equal(neigh_ind[:, :-1],
-                       neigh_ind_self[:, 1:])
-    assert_array_almost_equal(neigh_dist[:, :-1],
-                              neigh_dist_self[:, 1:])
+        assert (neigh_ind[:, :-1] == neigh_ind_self[:, 1:]).mean() >= 0.95
+        assert (np.abs(neigh_dist[:, :-1] - neigh_dist_self[:, 1:]) < 0.0001).mean() >= 0.95
+    else:
+        assert_array_equal(neigh_ind, ind_only)
+        assert_array_equal(neigh_ind_self, ind_only_self)
+
+        assert_array_equal(neigh_ind[:, :-1],
+                           neigh_ind_self[:, 1:])
+        assert_array_almost_equal(neigh_dist[:, :-1],
+                                  neigh_dist_self[:, 1:])
 
 
-@pytest.mark.skipif(sys.platform == 'win32', reason='Currently no LSH supported on Windows.')
+@pytest.mark.parametrize('LSH', LSH_WITH_RADIUS)
 @pytest.mark.parametrize('metric', ['euclidean', 'cosine'])
 @pytest.mark.parametrize('n_jobs', [-1, 1, None])
 @pytest.mark.parametrize('verbose', [0, 1])
-def test_radius_neighbors_with_or_without_self_hit(metric, n_jobs, verbose):
+def test_radius_neighbors_with_or_without_self_hit(LSH, metric, n_jobs, verbose):
     X, y = make_classification()
-    lsh = FalconnLSH(metric=metric, n_jobs=n_jobs, verbose=verbose)
+    lsh = LSH(metric=metric, n_jobs=n_jobs, verbose=verbose)
     lsh.fit(X, y)
     radius = lsh.kneighbors(n_candidates=3)[0][:, 2].max()
     neigh_dist, neigh_ind = lsh.radius_neighbors(return_distance=True, radius=radius)
@@ -59,32 +74,38 @@ def test_radius_neighbors_with_or_without_self_hit(metric, n_jobs, verbose):
                                   neigh_dist_self[i][1:4])
 
 
-@pytest.mark.skipif(sys.platform == 'win32', reason='Currently no LSH supported on Windows.')
-def test_squared_euclidean_same_neighbors_as_euclidean():
+@pytest.mark.parametrize('LSH', LSH_METHODS)
+def test_squared_euclidean_same_neighbors_as_euclidean(LSH):
     X, y = make_classification()
-    lsh = FalconnLSH(metric='minkowski')
+    lsh = LSH(metric='minkowski')
     lsh.fit(X, y)
     neigh_dist_eucl, neigh_ind_eucl = lsh.kneighbors()
-    radius = neigh_dist_eucl[:, 2].max()
-    rad_dist_eucl, rad_ind_eucl = lsh.radius_neighbors(radius=radius)
 
-    lsh = FalconnLSH(metric='sqeuclidean')
-    lsh.fit(X, y)
-    neigh_dist_sqeucl, neigh_ind_sqeucl = lsh.kneighbors()
-    rad_dist_sqeucl, rad_ind_sqeucl = lsh.radius_neighbors(radius=radius**2)
+    lsh_sq = LSH(metric='sqeuclidean')
+    lsh_sq.fit(X, y)
+    neigh_dist_sqeucl, neigh_ind_sqeucl = lsh_sq.kneighbors()
 
-    assert_array_equal(neigh_ind_eucl, neigh_ind_sqeucl)
-    assert_array_almost_equal(neigh_dist_eucl ** 2, neigh_dist_sqeucl)
-    for i in range(len(rad_ind_eucl)):
-        assert_array_equal(rad_ind_eucl[i], rad_ind_sqeucl[i])
-        assert_array_almost_equal(rad_dist_eucl[i] ** 2, rad_dist_sqeucl[i])
+    if issubclass(LSH, PuffinnLSH):
+        assert (neigh_ind_eucl == neigh_ind_sqeucl).mean() >= 0.95
+        assert (np.abs(neigh_dist_eucl ** 2 - neigh_dist_sqeucl) < 0.0001).mean() >= 0.95
+    else:
+        assert_array_equal(neigh_ind_eucl, neigh_ind_sqeucl)
+        assert_array_almost_equal(neigh_dist_eucl ** 2, neigh_dist_sqeucl)
+
+    if LSH in LSH_WITH_RADIUS:
+        radius = neigh_dist_eucl[:, 2].max()
+        rad_dist_eucl, rad_ind_eucl = lsh.radius_neighbors(radius=radius)
+        rad_dist_sqeucl, rad_ind_sqeucl = lsh_sq.radius_neighbors(radius=radius**2)
+        for i in range(len(rad_ind_eucl)):
+            assert_array_equal(rad_ind_eucl[i], rad_ind_sqeucl[i])
+            assert_array_almost_equal(rad_dist_eucl[i] ** 2, rad_dist_sqeucl[i])
 
 
-@pytest.mark.skipif(sys.platform == 'win32', reason='Currently no LSH supported on Windows.')
+@pytest.mark.parametrize('LSH', LSH_METHODS)
 @pytest.mark.parametrize('metric', ['invalid', 'manhattan', 'l1', 'chebyshev'])
-def test_warn_on_invalid_metric(metric):
-    X, y = make_classification()
-    lsh = FalconnLSH(metric='euclidean')
+def test_warn_on_invalid_metric(LSH, metric):
+    X, y = make_classification(random_state=24643)
+    lsh = LSH(metric='euclidean')
     lsh.fit(X, y)
     neigh_dist, neigh_ind = lsh.kneighbors()
 
@@ -93,5 +114,9 @@ def test_warn_on_invalid_metric(metric):
         lsh.fit(X, y)
     neigh_dist_inv, neigh_ind_inv = lsh.kneighbors()
 
-    assert_array_equal(neigh_ind, neigh_ind_inv)
-    assert_array_almost_equal(neigh_dist, neigh_dist_inv)
+    if issubclass(LSH, PuffinnLSH):
+        assert (neigh_ind == neigh_ind_inv).mean() >= 0.90
+        assert (np.abs(neigh_dist - neigh_dist_inv) < 0.0001).mean() >= 0.90
+    else:
+        assert_array_equal(neigh_ind, neigh_ind_inv)
+        assert_array_almost_equal(neigh_dist, neigh_dist_inv)

--- a/skhubness/neighbors/tests/test_neighbors.py
+++ b/skhubness/neighbors/tests/test_neighbors.py
@@ -192,7 +192,7 @@ def test_unsupervised_inputs(hubness_and_params):
               neighbors.RandomProjectionTree(n_candidates=1).fit(X),
               ]
     if sys.platform != 'win32':
-        inputs += [neighbors.LSH(n_candidates=1).fit(X), ]
+        inputs += [neighbors.FalconnLSH(n_candidates=1).fit(X), ]
 
     for input_ in inputs:
         nbrs.fit(input_)
@@ -1492,7 +1492,7 @@ def test_k_and_radius_neighbors_train_is_not_query(algorithm):
         assert_raises(ValueError, nn.radius_neighbors, [[2], [1]], radius=1.5)
     else:
         dist, ind = nn.radius_neighbors([[2], [1]], radius=1.5)
-        # sklearn does not guarantee sorted radius neighbors, but LSH sorts automatically,
+        # sklearn does not guarantee sorted radius neighbors, but FalconnLSH sorts automatically,
         # so we make sure, that all results here are sorted
         dist_true = [[1], [0, 1]]
         ind_true = [[1], [1, 0]]

--- a/skhubness/neighbors/unsupervised.py
+++ b/skhubness/neighbors/unsupervised.py
@@ -24,11 +24,12 @@ class NearestNeighbors(NeighborsBase, KNeighborsMixin,
         Range of parameter space to use by default for :meth:`radius_neighbors`
         queries.
 
-    algorithm: {'auto', 'hnsw', 'lsh', 'ball_tree', 'kd_tree', 'brute'}, optional
+    algorithm: {'auto', 'hnsw', 'lsh', 'falconn_lsh', 'ball_tree', 'kd_tree', 'brute'}, optional
         Algorithm used to compute the nearest neighbors:
 
         - 'hnsw' will use :class:`HNSW`
-        - 'lsh' will use :class:`LSH`
+        - 'lsh' will use :class:`PuffinnLSH`
+        - 'falconn_lsh' will use :class:`FalconnLSH`
         - 'ball_tree' will use :class:`BallTree`
         - 'kd_tree' will use :class:`KDTree`
         - 'brute' will use a brute-force search.


### PR DESCRIPTION
Introduce locality-sensitive hashing with the `puffinn` library #22 .
Per default, when using algorithm='lsh', now puffinn is used instead of falconn.
Puffinn is currently actively developed, and supports pickle-ing its index #20 #28 