### PR TITLE
Cache NGT

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,11 +25,11 @@ before_install:
   - travis/install-conda.sh
   - export PATH="$MINICONDA_DIR/bin:$PATH"
   - hash -r
-  - conda install -y numpy                                  # install optimized numpy first
-  - conda install -y llvm libgcc || true                    # Try to fix build errors on MacOS
-  - pip install pybind11                                    # so that nmslib can build
-  - travis/install-pip.sh                                   # install all the other requirements
-  - travis/install-build-puffinn.sh  # install from cache or build first
+  - conda install -y numpy                # install optimized numpy first
+  - conda install -y llvm libgcc || true  # Try to fix build errors on MacOS
+  - pip install pybind11                  # so that nmslib can build
+  - travis/install-pip.sh                 # install all the other requirements
+  - travis/install-build-puffinn.sh       # install from cache or build first
 
 install:
   - python3 setup.py build

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ cache:
       - "$HOME/.cache/pip"
       - "$HOME/virtualenv"
       - "$HOME/miniconda"
-      - "$HOME/ngt
+      - "$HOME/ngt"
       - "$HOME/Library/Caches/Homebrew"
 
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,6 @@ before_install:
   - export PATH="$MINICONDA_DIR/bin:$PATH"
   - hash -r
   - conda install -y numpy                # install optimized numpy first
-  - conda install -y llvm libgcc || true  # Try to fix build errors on MacOS
   - pip install pybind11                  # so that nmslib can build
   - travis/install-pip.sh                 # install all the other requirements
   - travis/install-build-puffinn.sh       # install from cache or build first

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,6 +63,7 @@ cache:
       - "$HOME/.cache/pip"
       - "$HOME/virtualenv"
       - "$HOME/miniconda"
+      - "$HOME/ngt
       - "$HOME/Library/Caches/Homebrew"
 
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,12 +15,6 @@ matrix:
       osx_image: xcode11
       sudo: true
 
-#addons:
-#  homebrew:
-#    packages:
-#    - cmake
-#    - gcc@9
-
 env:
   global:
   - CACHE_DIR="$HOME/virtualenv"
@@ -36,7 +30,6 @@ before_install:
   - pip install pybind11                                    # so that nmslib can build
   - travis/install-pip.sh                                   # install all the other requirements
   - travis/install-build-puffinn.sh  # install from cache or build first
-  - travis/install-build-ngtpy.sh                           # build and install NGT (others might be added)
 
 install:
   - python3 setup.py build

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ joblib>=0.12
 tqdm
 annoy
 nmslib
-ngt
+ngt>=1.7.10
 falconn
 pytest
 pytest-cov

--- a/travis/install-build-ngtpy.sh
+++ b/travis/install-build-ngtpy.sh
@@ -9,6 +9,10 @@ if [[ $(uname) == "Darwin" ]]; then
   echo "Running under Mac OS X and CPU..."
   sysctl machdep.cpu.brand_string
 
+  if pip install ngt; then
+    exit 0
+  fi
+
   # Setup environment
   /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
   echo "brew update && brew upgrade"
@@ -71,6 +75,10 @@ if [[ $(uname) == "Darwin" ]]; then
 elif [[ $(uname -s) == Linux* ]]; then
   echo "Running under Linux on CPU..."
   cat /proc/cpuinfo
+
+  if pip install ngt; then
+    exit 0
+  fi
 
   # Find the latest release
   FILE=$(curl -s https://api.github.com/repos/yahoojapan/NGT/releases/latest | grep zipball_url | cut -d '"' -f 4)

--- a/travis/install-build-ngtpy.sh
+++ b/travis/install-build-ngtpy.sh
@@ -9,7 +9,13 @@ if [[ $(uname) == "Darwin" ]]; then
   echo "Running under Mac OS X and CPU..."
   sysctl machdep.cpu.brand_string
 
-  if pip install ngt; then
+  if [ -d "$HOME/ngt" ]; then
+    # Control will enter here if dir exists.
+    echo "Found ngt dir, assuming it has been built and cached, directly pip installing ngt..."
+    cd "$HOME/ngt/*NGT*/build"  # could be NGT-v.x.x.x, or yahoojapan-NGT-v.x.x.x
+    sudo make install
+    export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/usr/local/lib64:/usr/local/lib"
+    pip install ngt
     exit 0
   fi
 
@@ -38,6 +44,8 @@ if [[ $(uname) == "Darwin" ]]; then
   export CXX=g++
   export CC=gcc
 
+  mkdir -p "$HOME/ngt"
+  cd "$HOME/ngt"
   # Find the latest release of NGT
   FILE=$(curl -s https://api.github.com/repos/yahoojapan/NGT/releases/latest | grep zipball_url | cut -d '"' -f 4)
   if [ -z "${FILE}" ]; then
@@ -76,9 +84,22 @@ elif [[ $(uname -s) == Linux* ]]; then
   echo "Running under Linux on CPU..."
   cat /proc/cpuinfo
 
-  if pip install ngt; then
+  if [ -d "$HOME/ngt" ]; then
+    # Control will enter here if dir exists.
+    echo "Found ngt dir, assuming it has been built and cached, directly pip installing ngt..."
+    cd "$HOME/ngt/*NGT*/build"  # could be NGT-v.x.x.x, or yahoojapan-NGT-v.x.x.x
+    sudo make install
+    # make library available
+    export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/usr/local/lib64:/usr/local/lib"
+    sudo ldconfig
+
+    pip install ngt
+
     exit 0
   fi
+
+  mkdir -p "$HOME/ngt"
+  cd "$HOME/ngt"
 
   # Find the latest release
   FILE=$(curl -s https://api.github.com/repos/yahoojapan/NGT/releases/latest | grep zipball_url | cut -d '"' -f 4)


### PR DESCRIPTION
Building NGT takes a lot of time on CI.
Let's first try to pip install ngt from cache (previously built ngt),
and only build, if this fails.