### PR TITLE
FEAT Enable ONNG provided by NGT

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ before_script:
   - flake8 --exit-zero .
 
 script:
-  - pytest skhubness --cov=skhubness
+  - travis_wait 20 pytest skhubness --cov=skhubness  # Prefix allow for <20min length tests
 
 after_success:
   # Only on linux, all libraries are supported, thus tested

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ additionally requires at least one of the following packges:
 * [`nmslib`](https://github.com/nmslib/nmslib)
     for hierachical navigable small-world graphs ('hnsw')
 * [`ngtpy`](https://github.com/yahoojapan/NGT/)
-    for nearest neighbor graphs ('onng')
+    for nearest neighbor graphs ('nng'), and variants (ANNG, ONNG)
 * [`puffinn`](https://github.com/puffinn/puffinn)
     for locality-sensitive hashing ('lsh')
 * [`falconn`](https://github.com/FALCONN-LIB/FALCONN)

--- a/docs/documentation/documentation.rst
+++ b/docs/documentation/documentation.rst
@@ -44,7 +44,7 @@ Neighbors: :mod:`skhubness.neighbors`
    neighbors.FalconnLSH
    neighbors.NearestCentroid
    neighbors.NearestNeighbors
-   neighbors.ONNG
+   neighbors.NNG
    neighbors.PuffinnLSH
    neighbors.RadiusNeighborsClassifier
    neighbors.RadiusNeighborsRegressor

--- a/docs/getting_started/installation.rst
+++ b/docs/getting_started/installation.rst
@@ -65,7 +65,7 @@ algorithms are currently supported on your operating system.
 +---------+-------------+-------+-------+---------+
 | annoy   | rptree      |   x   |   x   |    x    |
 +---------+-------------+-------+-------+---------+
-| ngtpy   | onng        |   x   |   x   |         |
+| ngtpy   | nng         |   x   |   x   |         |
 +---------+-------------+-------+-------+---------+
 | falconn | falconn_lsh |   x   |   x   |         |
 +---------+-------------+-------+-------+---------+

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ joblib>=0.12
 tqdm
 annoy
 nmslib
-ngt>=1.7.10
+ngt>=1.8
 falconn
 pytest
 pytest-cov

--- a/skhubness/neighbors/__init__.py
+++ b/skhubness/neighbors/__init__.py
@@ -12,7 +12,7 @@ from .graph import kneighbors_graph, radius_neighbors_graph
 from .hnsw import HNSW
 from .lsh import FalconnLSH, PuffinnLSH
 from .kd_tree import KDTree
-from .onng import ONNG
+from .nng import NNG
 from .random_projection_trees import RandomProjectionTree
 from .dist_metrics import DistanceMetric
 from .regression import KNeighborsRegressor, RadiusNeighborsRegressor
@@ -33,7 +33,7 @@ __all__ = ['BallTree',
            'NearestCentroid',
            'NearestNeighbors',
            'PuffinnLSH',
-           'ONNG',
+           'NNG',
            'RadiusNeighborsClassifier',
            'RadiusNeighborsRegressor',
            'RandomProjectionTree',

--- a/skhubness/neighbors/base.py
+++ b/skhubness/neighbors/base.py
@@ -38,7 +38,7 @@ from .approximate_neighbors import ApproximateNearestNeighbor, UnavailableANN
 from .hnsw import HNSW
 from .lsh import FalconnLSH
 from .lsh import PuffinnLSH
-from .onng import ONNG
+from .nng import NNG
 from .random_projection_trees import RandomProjectionTree
 from ..reduction import NoHubnessReduction, LocalScaling, MutualProximity, DisSimLocal
 
@@ -50,7 +50,7 @@ __all__ = ['KNeighborsMixin', 'NeighborsBase', 'RadiusNeighborsMixin',
 
 VALID_METRICS = dict(lsh=PuffinnLSH.valid_metrics if not issubclass(PuffinnLSH, UnavailableANN) else [],
                      falconn_lsh=FalconnLSH.valid_metrics if not issubclass(FalconnLSH, UnavailableANN) else [],
-                     onng=ONNG.valid_metrics if not issubclass(ONNG, UnavailableANN) else [],
+                     nng=NNG.valid_metrics if not issubclass(NNG, UnavailableANN) else [],
                      hnsw=HNSW.valid_metrics,
                      rptree=RandomProjectionTree.valid_metrics,
                      ball_tree=BallTree.valid_metrics,
@@ -68,7 +68,7 @@ VALID_METRICS = dict(lsh=PuffinnLSH.valid_metrics if not issubclass(PuffinnLSH, 
 
 VALID_METRICS_SPARSE = dict(lsh=[],
                             falconn_lsh=[],
-                            onng=[],
+                            nng=[],
                             hnsw=[],
                             rptree=[],
                             ball_tree=[],
@@ -77,8 +77,8 @@ VALID_METRICS_SPARSE = dict(lsh=[],
                                    - {'haversine'}),
                             )
 
-ALG_WITHOUT_RADIUS_QUERY = ['hnsw', 'lsh', 'rptree', 'onng', ]
-ANN_ALG = ['hnsw', 'lsh', 'falconn_lsh', 'rptree', 'onng', ]
+ALG_WITHOUT_RADIUS_QUERY = ['hnsw', 'lsh', 'rptree', 'nng', ]
+ANN_ALG = ['hnsw', 'lsh', 'falconn_lsh', 'rptree', 'nng', ]
 
 
 def _check_weights(weights):
@@ -286,8 +286,8 @@ class NeighborsBase(SklearnNeighborsBase):
             elif isinstance(X, FalconnLSH):
                 self._fit_X = X.X_train_
                 self._fit_method = 'falconn_lsh'
-            elif isinstance(X, ONNG):
-                self._fit_method = 'onng'
+            elif isinstance(X, NNG):
+                self._fit_method = 'nng'
             elif isinstance(X, HNSW):
                 self._fit_method = 'hnsw'
             elif isinstance(X, RandomProjectionTree):
@@ -364,8 +364,8 @@ class NeighborsBase(SklearnNeighborsBase):
             self._index = FalconnLSH(verbose=self.verbose, **self.algorithm_params)
             self._index.fit(X)
             self._tree = None
-        elif self._fit_method == 'onng':
-            self._index = ONNG(verbose=self.verbose, **self.algorithm_params)
+        elif self._fit_method == 'nng':
+            self._index = NNG(verbose=self.verbose, **self.algorithm_params)
             self._index.fit(X)
             self._tree = None
         elif self._fit_method == 'hnsw':
@@ -534,7 +534,7 @@ class NeighborsBase(SklearnNeighborsBase):
                     X[s], n_neighbors, return_distance)
                 for s in gen_even_slices(X.shape[0], n_jobs)
             )
-        elif self._fit_method in ['lsh', 'falconn_lsh', 'rptree', 'onng', ]:
+        elif self._fit_method in ['lsh', 'falconn_lsh', 'rptree', 'nng', ]:
             # assume joblib>=0.12
             delayed_query = delayed(self._index.kneighbors)
             parallel_kwargs = {"prefer": "threads"}

--- a/skhubness/neighbors/classification.py
+++ b/skhubness/neighbors/classification.py
@@ -48,13 +48,13 @@ class KNeighborsClassifier(NeighborsBase, KNeighborsMixin,
           array of distances, and returns an array of the same shape
           containing the weights.
 
-    algorithm : {'auto', 'hnsw', 'lsh', 'falconn_lsh', 'onng', 'rptree', 'ball_tree', 'kd_tree', 'brute'}, optional
+    algorithm : {'auto', 'hnsw', 'lsh', 'falconn_lsh', 'nng', 'rptree', 'ball_tree', 'kd_tree', 'brute'}, optional
         Algorithm used to compute the nearest neighbors:
 
         - 'hnsw' will use :class:`HNSW`
         - 'lsh' will use :class:`PuffinnLSH`
         - 'falconn_lsh' will use :class:`FalconnLSH`
-        - 'onng' will use :class:`ONNG`
+        - 'nng' will use :class:`NNG`
         - 'rptree' will use :class:`RandomProjectionTree`
         - 'ball_tree' will use :class:`BallTree`
         - 'kd_tree' will use :class:`KDTree`

--- a/skhubness/neighbors/lof.py
+++ b/skhubness/neighbors/lof.py
@@ -42,13 +42,13 @@ class LocalOutlierFactor(NeighborsBase, KNeighborsMixin, UnsupervisedMixin,
         If n_neighbors is larger than the number of samples provided,
         all samples will be used.
 
-    algorithm : {'auto', 'hnsw', 'lsh', 'falconn_lsh', 'onng', 'rptree', 'ball_tree', 'kd_tree', 'brute'}, optional
+    algorithm : {'auto', 'hnsw', 'lsh', 'falconn_lsh', 'nng', 'rptree', 'ball_tree', 'kd_tree', 'brute'}, optional
         Algorithm used to compute the nearest neighbors:
 
         - 'hnsw' will use :class:`HNSW`
         - 'lsh' will use :class:`PuffinnLSH`
         - 'falconn_lsh' will use :class:`FalconnLSH`
-        - 'onng' will use :class:`ONNG`
+        - 'nng' will use :class:`NNG`
         - 'rptree' will use :class:`RandomProjectionTree`
         - 'ball_tree' will use :class:`BallTree`
         - 'kd_tree' will use :class:`KDTree`

--- a/skhubness/neighbors/regression.py
+++ b/skhubness/neighbors/regression.py
@@ -54,13 +54,13 @@ class KNeighborsRegressor(NeighborsBase, KNeighborsMixin,
 
         Uniform weights are used by default.
 
-    algorithm : {'auto', 'hnsw', 'lsh', 'falconn_lsh', 'onng', 'rptree', 'ball_tree', 'kd_tree', 'brute'}, optional
+    algorithm : {'auto', 'hnsw', 'lsh', 'falconn_lsh', 'nng', 'rptree', 'ball_tree', 'kd_tree', 'brute'}, optional
         Algorithm used to compute the nearest neighbors:
 
         - 'hnsw' will use :class:`HNSW`
         - 'lsh' will use :class:`PuffinnLSH`
         - 'falconn_lsh' will use :class:`FalconnLSH`
-        - 'onng' will use :class:`ONNG`
+        - 'nng' will use :class:`NNG`
         - 'rptree' will use :class:`RandomProjectionTree`
         - 'ball_tree' will use :class:`BallTree`
         - 'kd_tree' will use :class:`KDTree`

--- a/skhubness/neighbors/tests/test_neighbors.py
+++ b/skhubness/neighbors/tests/test_neighbors.py
@@ -91,8 +91,6 @@ current_os = platform.system()
 # Skip certain tests, e.g. on certain platforms, when libraries don't support them
 FALCONN_LSH_NOT_ON_WIN = pytest.param(
     'falconn_lsh', marks=pytest.mark.skipif(sys.platform == 'win32', reason='falconn does not support Windows'))
-ONNG_NOT_ON_WIN = pytest.param(
-    'nng', marks=pytest.mark.skipif(sys.platform == 'win32', reason='NGT (NNG) does not support Windows'))
 HNSW_HAS_NO_RADIUS_QUERY = pytest.param('hnsw', marks=pytest.mark.xfail(
     reason="hnsw does not support radius queries"))
 ANNOY_HAS_NO_RADIUS_QUERY = pytest.param('rptree', marks=pytest.mark.xfail(

--- a/skhubness/neighbors/tests/test_neighbors.py
+++ b/skhubness/neighbors/tests/test_neighbors.py
@@ -92,13 +92,13 @@ current_os = platform.system()
 FALCONN_LSH_NOT_ON_WIN = pytest.param(
     'falconn_lsh', marks=pytest.mark.skipif(sys.platform == 'win32', reason='falconn does not support Windows'))
 ONNG_NOT_ON_WIN = pytest.param(
-    'onng', marks=pytest.mark.skipif(sys.platform == 'win32', reason='NGT (ONNG) does not support Windows'))
+    'nng', marks=pytest.mark.skipif(sys.platform == 'win32', reason='NGT (NNG) does not support Windows'))
 HNSW_HAS_NO_RADIUS_QUERY = pytest.param('hnsw', marks=pytest.mark.xfail(
     reason="hnsw does not support radius queries"))
 ANNOY_HAS_NO_RADIUS_QUERY = pytest.param('rptree', marks=pytest.mark.xfail(
     reason="annoy (rptree) does not support radius queries"))
-NGT_HAS_NO_RADIUS_QUERY = pytest.param('onng', marks=pytest.mark.xfail(
-    reason="NGT (ONNG) does not support radius queries"))
+NGT_HAS_NO_RADIUS_QUERY = pytest.param('nng', marks=pytest.mark.xfail(
+    reason="NGT (NNG) does not support radius queries"))
 
 
 def _weight_func(dist):
@@ -1081,9 +1081,9 @@ def test_neighbors_iris(algorithm, hubness_algorithm_and_params):
     clf.fit(iris.data, iris.target)
     y_pred = clf.predict(iris.data)
 
-    if hubness is None and algorithm == 'onng':
+    if hubness is None and algorithm == 'nng':
         assert np.mean(y_pred == iris.target) > 0.85, f'Below 85% accuracy'
-    elif hubness == 'dsl' or (algorithm == 'hnsw' and hubness in ['mp']) or algorithm in ['onng', 'lsh']:
+    elif hubness == 'dsl' or (algorithm == 'hnsw' and hubness in ['mp']) or algorithm in ['nng', 'lsh']:
         # Spurious small errors occur
         assert np.mean(y_pred == iris.target) > 0.90, f'Below 90% accuracy'
     else:
@@ -1740,7 +1740,7 @@ def test_knn_forcing_backend(backend, algorithm):
             if backend in ['loky']:
                 if algorithm == 'lsh':
                     pytest.skip(f'{algorithm} provided by puffinn does not work with loky.')
-                elif algorithm in ['onng']:
+                elif algorithm in ['nng']:
                     pytest.skip(f'{algorithm} provided by ngt is unstable in combination with loky.')
             if algorithm in ['rptree'] and backend in ['loky'] and current_os in ['Linux'] and is_travis:
                 pytest.skip(f'Annoy with backend loky on linux does not work on travis '

--- a/skhubness/neighbors/tests/test_onng.py
+++ b/skhubness/neighbors/tests/test_onng.py
@@ -6,10 +6,10 @@ from sklearn.datasets import make_classification
 from sklearn.utils.estimator_checks import check_estimator
 from sklearn.utils.testing import assert_array_equal, assert_array_almost_equal
 from sklearn.utils.testing import assert_raises
-from skhubness.neighbors import ONNG, NearestNeighbors
+from skhubness.neighbors import NNG, NearestNeighbors
 
 
-@pytest.mark.skipif(sys.platform == 'win32', reason='ONNG not supported on Windows.')
+@pytest.mark.skipif(sys.platform == 'win32', reason='NGT not supported on Windows.')
 @pytest.mark.parametrize('n_candidates', [1, 2, 5, 99, 100, 1000, ])
 @pytest.mark.parametrize('set_in_constructor', [True, False])
 @pytest.mark.parametrize('return_distance', [True, False])
@@ -22,8 +22,8 @@ def test_return_correct_number_of_neighbors(n_candidates: int,
                                             verbose: bool):
     n_samples = 100
     X, y = make_classification(n_samples=n_samples)
-    ann = ONNG(n_candidates=n_candidates, verbose=verbose)\
-        if set_in_constructor else ONNG(verbose=verbose)
+    ann = NNG(n_candidates=n_candidates, verbose=verbose)\
+        if set_in_constructor else NNG(verbose=verbose)
     ann.fit(X, y)
     X_query = None if search_among_indexed else X
     neigh = ann.kneighbors(X_query, return_distance=return_distance) if set_in_constructor\
@@ -40,26 +40,26 @@ def test_return_correct_number_of_neighbors(n_candidates: int,
         assert np.all(neigh[:, n_samples:] == -1), f'Returned indices for invalid neighbors'
 
 
-@pytest.mark.skipif(sys.platform == 'win32', reason='ONNG not supported on Windows.')
+@pytest.mark.skipif(sys.platform == 'win32', reason='NGT not supported on Windows.')
 @pytest.mark.parametrize('metric', ['invalid', None])
 def test_invalid_metric(metric):
     X, y = make_classification(n_samples=10, n_features=10)
-    ann = ONNG(metric=metric)
+    ann = NNG(metric=metric)
     with assert_raises(ValueError):
         _ = ann.fit(X, y)
 
 
-@pytest.mark.skipif(sys.platform == 'win32', reason='ONNG not supported on Windows.')
-@pytest.mark.parametrize('metric', ONNG.valid_metrics)
+@pytest.mark.skipif(sys.platform == 'win32', reason='NGT not supported on Windows.')
+@pytest.mark.parametrize('metric', NNG.valid_metrics)
 @pytest.mark.parametrize('n_jobs', [-1, 1, None])
 @pytest.mark.parametrize('verbose', [0, 1])
 def test_kneighbors_with_or_without_distances(metric, n_jobs, verbose):
     n_samples = 100
     X = np.random.RandomState(1235232).rand(n_samples, 2)
-    ann = ONNG(metric=metric,
-               n_jobs=n_jobs,
-               verbose=verbose,
-               )
+    ann = NNG(metric=metric,
+              n_jobs=n_jobs,
+              verbose=verbose,
+              )
     ann.fit(X)
     neigh_dist_self, neigh_ind_self = ann.kneighbors(X, return_distance=True)
     ind_only_self = ann.kneighbors(X, return_distance=False)
@@ -82,14 +82,14 @@ def test_kneighbors_with_or_without_distances(metric, n_jobs, verbose):
         assert_array_almost_equal(neigh_dist_self[:, 0], np.zeros(len(neigh_dist_self)))
 
 
-@pytest.mark.skipif(sys.platform == 'win32', reason='ONNG not supported on Windows.')
-@pytest.mark.parametrize('metric', ONNG.valid_metrics)
+@pytest.mark.skipif(sys.platform == 'win32', reason='NGT not supported on Windows.')
+@pytest.mark.parametrize('metric', NNG.valid_metrics)
 def test_kneighbors_with_or_without_self_hit(metric):
     X = np.random.RandomState(1245544).rand(50, 2)
     n_candidates = 5
-    ann = ONNG(metric=metric,
-               n_candidates=n_candidates,
-               )
+    ann = NNG(metric=metric,
+              n_candidates=n_candidates,
+              )
     ann.fit(X)
     ind_self = ann.kneighbors(X, n_candidates=n_candidates+1, return_distance=False)
     ind_no_self = ann.kneighbors(n_candidates=n_candidates, return_distance=False)
@@ -102,14 +102,14 @@ def test_kneighbors_with_or_without_self_hit(metric):
         assert_array_equal(ind_self[:, 1:], ind_no_self)
 
 
-@pytest.mark.skipif(sys.platform == 'win32', reason='ONNG not supported on Windows.')
+@pytest.mark.skipif(sys.platform == 'win32', reason='NGT not supported on Windows.')
 def test_squared_euclidean_same_neighbors_as_euclidean():
     X, y = make_classification()
-    ann = ONNG(metric='euclidean')
+    ann = NNG(metric='euclidean')
     ann.fit(X, y)
     neigh_dist_eucl, neigh_ind_eucl = ann.kneighbors(X)
 
-    ann = ONNG(metric='sqeuclidean')
+    ann = NNG(metric='sqeuclidean')
     ann.fit(X, y)
     neigh_dist_sqeucl, neigh_ind_sqeucl = ann.kneighbors(X)
 
@@ -117,39 +117,39 @@ def test_squared_euclidean_same_neighbors_as_euclidean():
     assert_array_almost_equal(neigh_dist_eucl ** 2, neigh_dist_sqeucl)
 
 
-@pytest.mark.skipif(sys.platform == 'win32', reason='ONNG not supported on Windows.')
+@pytest.mark.skipif(sys.platform == 'win32', reason='NGT not supported on Windows.')
 def test_same_neighbors_as_with_exact_nn_search():
     X = np.random.RandomState(42).randn(10, 2)
 
     nn = NearestNeighbors()
     nn_dist, nn_neigh = nn.fit(X).kneighbors(return_distance=True)
 
-    ann = ONNG()
+    ann = NNG()
     ann_dist, ann_neigh = ann.fit(X).kneighbors(return_distance=True)
 
     assert_array_almost_equal(ann_dist, nn_dist, decimal=5)
     assert_array_almost_equal(ann_neigh, nn_neigh, decimal=0)
 
 
-@pytest.mark.skipif(sys.platform == 'win32', reason='ONNG not supported on Windows.')
+@pytest.mark.skipif(sys.platform == 'win32', reason='NGT not supported on Windows.')
 def test_is_valid_estimator_in_persistent_memory():
-    check_estimator(ONNG)
+    check_estimator(NNG)
 
 
-@pytest.mark.skipif(sys.platform == 'win32', reason='ONNG not supported on Windows.')
+@pytest.mark.skipif(sys.platform == 'win32', reason='NGT not supported on Windows.')
 @pytest.mark.xfail(reason='ngtpy.Index can not be pickled as of v1.7.6')
 def test_is_valid_estimator_in_main_memory():
-    check_estimator(ONNG(index_dir=None))
+    check_estimator(NNG(index_dir=None))
 
 
-@pytest.mark.skipif(sys.platform == 'win32', reason='ONNG not supported on Windows.')
+@pytest.mark.skipif(sys.platform == 'win32', reason='NGT not supported on Windows.')
 @pytest.mark.parametrize('index_dir', [tuple(), 0, 'auto', '/dev/shm', '/tmp', None])
 def test_memory_mapped(index_dir):
     X, y = make_classification(n_samples=10,
                                n_features=5,
                                random_state=123,
                                )
-    ann = ONNG(index_dir=index_dir)
+    ann = NNG(index_dir=index_dir)
     if isinstance(index_dir, str) or index_dir is None:
         ann.fit(X, y)
         _ = ann.kneighbors(X)
@@ -157,3 +157,22 @@ def test_memory_mapped(index_dir):
     else:
         with np.testing.assert_raises(TypeError):
             ann.fit(X, y)
+
+
+@pytest.mark.skipif(sys.platform == 'win32', reason='NGT not supported on Windows')
+def test_nng_optimization():
+    X, y = make_classification(n_samples=150,
+                               n_features=2,
+                               n_redundant=0,
+                               random_state=123,
+                               )
+    ann = NNG(index_dir='/dev/shm',
+              optimize=True,
+              edge_size_for_search=40,
+              edge_size_for_creation=10,
+              epsilon=0.1,
+              n_jobs=2,
+              )
+    ann.fit(X, y)
+    _ = ann.kneighbors(X, )
+    _ = ann.kneighbors()

--- a/skhubness/neighbors/unsupervised.py
+++ b/skhubness/neighbors/unsupervised.py
@@ -24,13 +24,13 @@ class NearestNeighbors(NeighborsBase, KNeighborsMixin,
         Range of parameter space to use by default for :meth:`radius_neighbors`
         queries.
 
-    algorithm : {'auto', 'hnsw', 'lsh', 'falconn_lsh', 'onng', 'rptree', 'ball_tree', 'kd_tree', 'brute'}, optional
+    algorithm : {'auto', 'hnsw', 'lsh', 'falconn_lsh', 'nng', 'rptree', 'ball_tree', 'kd_tree', 'brute'}, optional
         Algorithm used to compute the nearest neighbors:
 
         - 'hnsw' will use :class:`HNSW`
         - 'lsh' will use :class:`PuffinnLSH`
         - 'falconn_lsh' will use :class:`FalconnLSH`
-        - 'onng' will use :class:`ONNG`
+        - 'nng' will use :class:`NNG`
         - 'rptree' will use :class:`RandomProjectionTree`
         - 'ball_tree' will use :class:`BallTree`
         - 'kd_tree' will use :class:`KDTree`

--- a/skhubness/utils/platform.py
+++ b/skhubness/utils/platform.py
@@ -11,7 +11,7 @@ def available_ann_algorithms_on_current_platform():
         * 'rptree': annoy
         * 'lsh': puffinn
         * 'falconn_lsh': falconn
-        * 'onng': NGT
+        * 'nng': NGT
 
     Returns
     -------
@@ -30,14 +30,14 @@ def available_ann_algorithms_on_current_platform():
             algorithms = ('falconn_lsh',
                           'hnsw',
                           'rptree',
-                          'onng',
+                          'nng',
                           )
         else:
             algorithms = ('falconn_lsh',
                           'lsh',
                           'hnsw',
                           'rptree',
-                          'onng',
+                          'nng',
                           )
     # Linux
     elif sys.platform == 'linux':
@@ -45,7 +45,7 @@ def available_ann_algorithms_on_current_platform():
                       'falconn_lsh',
                       'hnsw',
                       'rptree',
-                      'onng',
+                      'nng',
                       )
     # others: undefined
     else:  # pragma: no cover


### PR DESCRIPTION
Since NGT 1.8 ONNG optimization is available via the Python API.
We can, therefore, now enable ONNG here.

The wrapper is renamed to `NNG` in order to make clear that
first, the standard ANNG is created in any case. Only when the
parameter `optimize=True` is set, the ANNG is optimized to an ONNG.

