### PR TITLE
MNT update citation, copyright, travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ before_script:
   - flake8 --exit-zero .
 
 script:
-  - travis_wait 20 pytest skhubness --cov=skhubness  # Prefix allow for <20min length tests
+  - pytest skhubness --cov=skhubness
 
 after_success:
   # Only on linux, all libraries are supported, thus tested

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,19 @@
-lanuage: python
+language: python
 
 python:
   - '3.7'
+  - '3.8'
 
-matrix:
+jobs:
+  allow_failures:
+    - os: osx
   include:
     - os: linux
       dist: xenial
-      sudo: true
     - os: osx
       osx_image: xcode10.3  # default is 9.x, which fails
-      sudo: true
     - os: osx
       osx_image: xcode11
-      sudo: true
 
 env:
   global:

--- a/README.md
+++ b/README.md
@@ -173,15 +173,28 @@ here on GitHub.
 For more information about contributing, please have a look at the
 [contributors guidelines](CONTRIBUTING.rst).
 
-    (c) 2018-2019, Roman Feldbauer
+    (c) 2018-2020, Roman Feldbauer
     Austrian Research Institute for Artificial Intelligence (OFAI) and
     University of Vienna, Division of Computational Systems Biology (CUBE)
     Contact: <roman.feldbauer@univie.ac.at>
 
 ## Citation
 
-A software publication paper is currently in preparation. Until then,
-if you use `scikit-hubness` in your scientific publication, please cite:
+If you use `scikit-hubness` in your scientific publication, please cite:
+
+    @Article{Feldbauer2020,
+      author  = {Roman Feldbauer and Thomas Rattei and Arthur Flexer},
+      title   = {scikit-hubness: Hubness Reduction and Approximate Neighbor Search},
+      journal = {Journal of Open Source Software},
+      year    = {2020},
+      volume  = {5},
+      number  = {45},
+      pages   = {1957},
+      issn    = {2475-9066},
+      doi     = {10.21105/joss.01957},
+    }
+
+To specifically acknowledge *approximate hubness reduction*, please cite:
 
     @INPROCEEDINGS{8588814,
     author={R. {Feldbauer} and M. {Leodolter} and C. {Plant} and A. {Flexer}},

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,7 +28,7 @@ for mod_name in MOCK_MODULES:
 # -- Project information -----------------------------------------------------
 
 project = 'scikit-hubness'
-copyright = '2019, Roman Feldbauer'
+copyright = '2020, Roman Feldbauer'
 author = 'Roman Feldbauer'
 
 # The full version, including alpha/beta/rc tags

--- a/paper/joss/paper.md
+++ b/paper/joss/paper.md
@@ -51,7 +51,7 @@ classification [@Radovanovic2010],
 clustering [@Schnitzer2015],
 or visualization [@Flexer2015a].
 Hubness is known to affect a variety of applied learning systems [@Angiulli2018],
-causing  &mdash; for instance  &mdash; overrepresentation of certain songs in music recommendations [@Flexer2018],
+causing&mdash;for instance&mdash;overrepresentation of certain songs in music recommendations [@Flexer2018],
 or improper transport mode detection [@Feldbauer2018].
 
 Multiple hubness reduction algorithms have been developed to mitigate these
@@ -98,25 +98,13 @@ and the general ``kneighbors_graph``.
 
 ``scikit-hubness`` is developed using several quality assessment tools and principles,
 such as PEP8 compliance, unit tests with high code coverage, continuous integration
-on all major platforms
-(Linux and MacOS [1],
-Windows [2]),
-and additional checks by LGTM [3].
-The source code is available at GitHub [4]
+on all major platforms (Linux, MacOS, Windows),
+and additional checks by LGTM.
+The source code is available at https://github.com/VarIr/scikit-hubness
 under the BSD 3-clause license.
-The online documentation is available at Read the Docs [5].
+The online documentation is available at https://scikit-hubness.readthedocs.io/.
 Install from the Python package index
 with ``$ pip install scikit-hubness``.
-
-[1] https://travis-ci.com/VarIr/scikit-hubness/
-
-[2] https://ci.appveyor.com/project/VarIr/scikit-hubness
-
-[3] https://lgtm.com/projects/g/VarIr/scikit-hubness/
-
-[4] https://github.com/VarIr/scikit-hubness 
-
-[5] https://scikit-hubness.readthedocs.io/
 
 # Outlook
 
@@ -132,9 +120,6 @@ which will (1) accelerate development,
 (2) simplify addition of new hubness reduction and approximate search methods, and
 (3) facilitate more flexible usage.
 
-[//]: #  (https://github.com/scikit-learn/scikit-learn/pull/10482)
-[//]: #  (and, thus, between the main development
-phase of scikit-hubness and submission of this manuscript)
 # Acknowledgements
 
 We thank Silvan David Peter for testing the software.<br/>

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ This file is part of the scikit-hubness package available at
 https://github.com/VarIr/scikit-hubness/
 The scikit-hubness package is licensed under the terms the BSD 3-Clause license.
 
-(c) 2018-2019, Roman Feldbauer
+(c) 2018-2020, Roman Feldbauer
 Austrian Research Institute for Artificial Intelligence (OFAI) and
 University of Vienna, Division of Computational Systems Biology (CUBE)
 Contact: <roman.feldbauer@univie.ac.at>

--- a/skhubness/analysis/estimation.py
+++ b/skhubness/analysis/estimation.py
@@ -7,7 +7,7 @@ This file is part of scikit-hubness.
 The package is available at https://github.com/VarIr/scikit-hubness/
 and distributed under the terms of the BSD-3 license.
 
-(c) 2018-2019, Roman Feldbauer
+(c) 2018-2020, Roman Feldbauer
 Austrian Research Institute for Artificial Intelligence (OFAI) and
 University of Vienna, Division of Computational Systems Biology (CUBE)
 Contact: <roman.feldbauer@univie.ac.at>


### PR DESCRIPTION
Point citation to JOSS paper.
Update copyright to 2020.
Do not let travis wait for 20min anymore, as tests are now faster due to `puffinn` improvements.