### PR TITLE
FIX hubness estimation error on negative nn indices

### DIFF
--- a/skhubness/analysis/estimation.py
+++ b/skhubness/analysis/estimation.py
@@ -613,6 +613,13 @@ class Hubness(BaseEstimator):
         if self.store_k_neighbors:
             self.k_neighbors = k_neighbors
 
+        # Negative indices can occur, when ANN does not find enough neighbors,
+        # and must be removed
+        mask = k_neighbors < 0
+        if np.any(mask):
+            k_neighbors = k_neighbors[~mask]
+            del mask
+
         k_occurrence = np.bincount(
             k_neighbors.astype(int).ravel(), minlength=n_train)
         if self.store_k_occurrence:

--- a/skhubness/analysis/tests/test_estimation.py
+++ b/skhubness/analysis/tests/test_estimation.py
@@ -280,3 +280,15 @@ def test_hubness_independent_on_data_set_size(hubness_measure):
             np.testing.assert_allclose(value[-1], value[0], rtol=0.1)
     else:
         np.testing.assert_allclose(value[-1], value[0], rtol=2e-1)
+
+
+def test_handle_negative_neighbor_indices():
+    def mock_kneighbors(X_test):
+        nn = np.zeros((len(X_test), 2), dtype=int)
+        nn[:, 1] = -1
+        return nn
+    X, _ = make_classification(n_samples=10)
+    hub = Hubness()
+    hub.fit(X[:8, :])
+    hub._k_neighbors = mock_kneighbors
+    hub.score(X[8:, :])

--- a/skhubness/neighbors/tests/test_lsh.py
+++ b/skhubness/neighbors/tests/test_lsh.py
@@ -119,3 +119,14 @@ def test_warn_on_invalid_metric(LSH, metric):
 
     assert_array_equal(neigh_ind, neigh_ind_inv)
     assert_array_almost_equal(neigh_dist, neigh_dist_inv)
+
+
+def test_puffinn_lsh_custom_memory():
+    # If user decides to set memory, this value should be selected,
+    # if it is higher than what the heuristic yields.
+    X, y = make_classification(n_samples=10)
+    memory = 2*1024**2
+    lsh = PuffinnLSH(n_candidates=2,
+                     memory=memory)
+    lsh.fit(X, y)
+    assert lsh.memory == memory

--- a/skhubness/neighbors/tests/test_lsh.py
+++ b/skhubness/neighbors/tests/test_lsh.py
@@ -121,6 +121,7 @@ def test_warn_on_invalid_metric(LSH, metric):
     assert_array_almost_equal(neigh_dist, neigh_dist_inv)
 
 
+@pytest.mark.skipif(sys.platform == 'win32', reason='Puffinn not supported on Windows.')
 def test_puffinn_lsh_custom_memory():
     # If user decides to set memory, this value should be selected,
     # if it is higher than what the heuristic yields.


### PR DESCRIPTION
Hubness estimation can error on negative neighbor indices that can occur
when ANN does not find enough neighbors. These are now filtered away for
hubness estimation.
Also slightly change how to select the memory available to puffinn.