### PR TITLE
MNT enable codecov on all platforms

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,8 +49,8 @@ script:
   - pytest skhubness --cov=skhubness
 
 after_success:
-  # Only on linux, all libraries are supported, thus tested
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then codecov; fi
+  # Coverage reports should be merged automatically by codecov
+  - codecov
 
 cache:
   - pip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -62,6 +62,8 @@ test_script:
   - "pytest"
 
 after_test:
+  # Coverage reports should be merged automatically by codecov
+  - "codecov"
   # If tests are successful, create binary packages for the project.
   - "python setup.py bdist_wheel"
   - "python setup.py bdist_wininst"

--- a/skhubness/neighbors/tests/test_lsh.py
+++ b/skhubness/neighbors/tests/test_lsh.py
@@ -10,10 +10,10 @@ from sklearn.utils.estimator_checks import check_estimator
 from skhubness.neighbors import FalconnLSH, PuffinnLSH
 
 # Exclude libraries that are not available on specific platforms
-if sys.platform == 'win32':  # pragma: no cover
+if sys.platform == 'win32':
     LSH_METHODS = ()
     LSH_WITH_RADIUS = ()
-elif sys.platform == 'darwin':  # pragma: no cover
+elif sys.platform == 'darwin':
     # Work-around for imprecise Puffinn on Mac: disable tests for now
     LSH_METHODS = (FalconnLSH, )
     LSH_WITH_RADIUS = (FalconnLSH, )

--- a/skhubness/utils/platform.py
+++ b/skhubness/utils/platform.py
@@ -19,12 +19,12 @@ def available_ann_algorithms_on_current_platform():
         A tuple of available algorithms
     """
     # Windows
-    if sys.platform == 'win32':  # pragma: no cover
+    if sys.platform == 'win32':
         algorithms = ('hnsw',
                       'rptree',
                       )
     # MacOS
-    elif sys.platform == 'darwin':  # pragma: no cover
+    elif sys.platform == 'darwin':
         if 'pytest' in sys.modules:
             # Work-around: Skip tests of PuffinnLSH on MacOS, as it appears to be less precise than on Linux...
             algorithms = ('falconn_lsh',


### PR DESCRIPTION
Atm, only Linux builds are checked for coverage.
Since codecov supposedly merges reports from different platforms automatically,
we could easily enable it on all platforms.