### PR TITLE
ENH sparse multilabel classification

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -59,7 +59,7 @@ build_script:
 
 test_script:
   # Run the project tests
-  - "pytest"
+  - "pytest --cov"
 
 after_test:
   # Coverage reports should be merged automatically by codecov

--- a/skhubness/__init__.py
+++ b/skhubness/__init__.py
@@ -3,7 +3,7 @@
 
 """ Python package for nearest neighbor retrieval in high-dimensional space."""
 
-__version__ = '0.21.2'
+__version__ = '0.21.3'
 
 from . import analysis
 from . import data

--- a/skhubness/analysis/estimation.py
+++ b/skhubness/analysis/estimation.py
@@ -341,11 +341,9 @@ class Hubness(BaseEstimator):
         """
         n_test, m_test = D.shape
         indices = np.zeros((n_test, self.k), dtype=np.int32)
-        if self.verbose:
-            range_n_test = tqdm(range(n_test))
-        else:
-            range_n_test = range(n_test)
-        for i in range_n_test:
+        for i in tqdm(range(n_test),
+                      disable=False if self.verbose else True,
+                      desc='k_neighbors'):
             d = D[i, :].copy()
             d[~np.isfinite(d)] = np.inf
             if self.shuffle_equal:
@@ -395,10 +393,9 @@ class Hubness(BaseEstimator):
             k_neighbors = X.indices[min_ind.ravel() + np.repeat(X.indptr[:-1], repeats=self.k)]
         else:
             k_neighbors = np.empty((n_test,), dtype=object)
-            if self.verbose:
-                range_n_test = tqdm(range(n_test))
-            else:
-                range_n_test = range(n_test)
+            range_n_test = tqdm(range(n_test),
+                                disable=False if self.verbose else True,
+                                desc='k_neighbors')
             if self.shuffle_equal:
                 for i in range_n_test:
                     x = X.getrow(i)

--- a/skhubness/analysis/estimation.py
+++ b/skhubness/analysis/estimation.py
@@ -442,7 +442,7 @@ class Hubness(BaseEstimator):
             Reverse nearest neighbor count for each object.
         limiting: 'memory' or 'cpu'
             If 'cpu', use fast implementation with high memory usage,
-            if 'memory', use slighly slower, but memory-efficient implementation,
+            if 'memory', use slightly slower, but memory-efficient implementation,
             otherwise use naive implementation (slow, low memory usage)
         """
         n = k_occurrence.size

--- a/skhubness/neighbors/base.py
+++ b/skhubness/neighbors/base.py
@@ -20,7 +20,7 @@ from functools import partial
 import warnings
 
 import numpy as np
-from scipy.sparse import issparse, csr_matrix
+from scipy.sparse import issparse, csr_matrix, csc_matrix, lil_matrix
 
 from sklearn.exceptions import DataConversionWarning
 from sklearn.neighbors.base import NeighborsBase as SklearnNeighborsBase
@@ -992,10 +992,14 @@ class SupervisedIntegerMixin:
 
         check_classification_targets(y)
         self.classes_ = []
-        self._y = np.empty(y.shape, dtype=np.int)
-        for k in range(self._y.shape[1]):
-            classes, self._y[:, k] = np.unique(y[:, k], return_inverse=True)
-            self.classes_.append(classes)
+        if issparse(y):
+            self._y = y
+            self.classes_ = np.tile([0, 1], (y.shape[1], 1))
+        else:
+            self._y = np.empty(y.shape, dtype=np.int)
+            for k in range(self._y.shape[1]):
+                classes, self._y[:, k] = np.unique(y[:, k], return_inverse=True)
+                self.classes_.append(classes)
 
         if not self.outputs_2d_:
             self.classes_ = self.classes_[0]

--- a/skhubness/neighbors/base.py
+++ b/skhubness/neighbors/base.py
@@ -157,6 +157,8 @@ class NeighborsBase(SklearnNeighborsBase):
             n_candidates = 1 if hubness is None else 100
             algorithm_params = {'n_candidates': n_candidates,
                                 'metric': metric}
+        if n_jobs is not None and 'n_jobs' not in algorithm_params:
+            algorithm_params['n_jobs'] = self.n_jobs
         if 'verbose' not in algorithm_params:
             algorithm_params['verbose'] = verbose
         hubness_params = hubness_params if hubness_params is not None else {}

--- a/skhubness/neighbors/classification.py
+++ b/skhubness/neighbors/classification.py
@@ -24,6 +24,7 @@ from tqdm.auto import tqdm
 
 from .base import _check_weights, _get_weights
 from .base import NeighborsBase, KNeighborsMixin, RadiusNeighborsMixin, SupervisedIntegerMixin
+from ..utils.multiprocessing import register_parallel_pytest_cov
 
 
 def _sparse_multilabel_classification(k_classes_k, y, neigh_ind, ):
@@ -210,6 +211,7 @@ class KNeighborsClassifier(NeighborsBase, KNeighborsMixin,
         if issparse(self._y):
             y_pred = lil_matrix((n_outputs, n_samples), dtype=classes_[0].dtype)
             if weights is None:
+                register_parallel_pytest_cov()
                 with mp.Pool(processes=self.n_jobs) as pool:
                     k_cls = list(tqdm(pool.imap_unordered(func=partial(_sparse_multilabel_classification,
                                                                        y=_y, neigh_ind=neigh_ind),

--- a/skhubness/neighbors/classification.py
+++ b/skhubness/neighbors/classification.py
@@ -30,7 +30,7 @@ def _sparse_multilabel_classification(k_classes_k, y, neigh_ind, ):
     """ Helper for parallel processing of sparse multilabel data. """
     k, classes_k = k_classes_k
     labels = y[neigh_ind, k].reshape(len(neigh_ind), -1)
-    mode = labels.getnnz(axis=1) >= labels.shape[1]
+    mode = labels.getnnz(axis=1) >= labels.shape[1] / 2
     mode = np.asarray(mode, dtype=np.intp)
     return k, classes_k.take(mode)
 

--- a/skhubness/neighbors/tests/test_classification.py
+++ b/skhubness/neighbors/tests/test_classification.py
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+import pytest
+import numpy as np
+from scipy.sparse import csr_matrix, issparse
+from sklearn.datasets import make_multilabel_classification
+from skhubness.neighbors import KNeighborsClassifier
+
+
+@pytest.mark.parametrize('n_jobs', [None, 1, 2])
+@pytest.mark.parametrize('n_neighbors', [1, 5])
+def test_sparse_multilabel_targets(n_neighbors, n_jobs):
+    X, y_dense = make_multilabel_classification(random_state=123)
+    thresh = 80
+
+    knn = KNeighborsClassifier(n_neighbors=n_neighbors,
+                               n_jobs=n_jobs, )
+    assert not issparse(y_dense)
+    knn.fit(X[:thresh], y_dense[:thresh])
+    y_pred = knn.predict(X[thresh:])
+
+    y_sparse = csr_matrix(y_dense)
+    knn = KNeighborsClassifier(n_neighbors=n_neighbors,
+                               n_jobs=n_jobs,)
+    assert issparse(y_sparse)
+    knn.fit(X[:thresh], y_sparse[:thresh])
+    y_pred_sparse = knn.predict(X[thresh:, :])
+
+    # Test array equality
+    np.testing.assert_array_equal(y_pred, y_pred_sparse.toarray())

--- a/skhubness/utils/multiprocessing.py
+++ b/skhubness/utils/multiprocessing.py
@@ -1,0 +1,7 @@
+def register_parallel_pytest_cov():
+    try:
+        from pytest_cov.embed import cleanup_on_sigterm
+    except ImportError:
+        pass
+    else:
+        cleanup_on_sigterm()


### PR DESCRIPTION
Sparse indicator target matrices in kNN are converted to dense arrays,
which can cause out-of-memory erros, when there are many classes,
and is likely inefficient already for not-so-many classes.

This PR makes use of the indicator matrix sparsity,
and parallelizes critical loops.

This also enables parallel ANN search, when no value is passed by the `algorithm_param` dict,
but only via class `n_jobs` arguments.
In addition, some `tqdm` calls are improved.