### PR TITLE
MNT NMSlibTransformer

### DIFF
--- a/skhubness/neighbors/_nmslib.py
+++ b/skhubness/neighbors/_nmslib.py
@@ -288,11 +288,6 @@ class NMSlibTransformer(BaseEstimator, TransformerMixin):
         self: NMSlibTransformer
             An instance of NMSlibTransformer with a built index
         """
-        X: Union[np.ndarray, csr_matrix] = check_array(X, accept_sparse=True)  # noqa
-        n_samples, n_features = X.shape
-        self.n_samples_in_ = n_samples
-        self.n_features_in_ = n_features
-
         space = {
             **{x: x for x in NMSlibTransformer.valid_metrics},
             "euclidean": "l2",
@@ -301,6 +296,12 @@ class NMSlibTransformer(BaseEstimator, TransformerMixin):
         if space is None:
             raise ValueError(f"Invalid metric: {self.metric}")
         self.space_ = space
+        self.sparse_ = "_sparse" in self.space_
+
+        X: Union[np.ndarray, csr_matrix] = check_array(X, accept_sparse=self.sparse_)  # noqa
+        n_samples, n_features = X.shape
+        self.n_samples_in_ = n_samples
+        self.n_features_in_ = n_features
 
         # Different nearest neighbor methods in NMSLIB have different parameters to tune,
         # and are passed as a dict to nmslib.init()
@@ -358,7 +359,7 @@ class NMSlibTransformer(BaseEstimator, TransformerMixin):
             The retrieved approximate nearest neighbors in the index for each query.
         """
         check_is_fitted(self, "neighbor_index_")
-        X: Union[np.ndarray, csr_matrix] = check_array(X, accept_sparse=True)  # noqa
+        X: Union[np.ndarray, csr_matrix] = check_array(X, accept_sparse=self.sparse_)  # noqa
 
         n_samples_transform, n_features_transform = X.shape
         if n_features_transform != self.n_features_in_:

--- a/skhubness/neighbors/tests/test_hnsw.py
+++ b/skhubness/neighbors/tests/test_hnsw.py
@@ -56,10 +56,9 @@ def test_kneighbors_with_or_without_self_hit(metric, n_jobs, verbose):
 
     assert_array_equal(neigh_ind_self, ind_only_self)
     assert_array_equal(neigh_ind_self[:, 0], np.arange(len(neigh_ind_self)))
-    if metric in ['cosine']:  # similarities in [0, 1]
-        assert_array_almost_equal(neigh_dist_self[:, 0], np.ones(len(neigh_dist_self)))
-    else:  # distances in [0, inf]
-        assert_array_almost_equal(neigh_dist_self[:, 0], np.zeros(len(neigh_dist_self)))
+
+    # distances in [0, inf]
+    assert_array_almost_equal(neigh_dist_self[:, 0], np.zeros(len(neigh_dist_self)))
 
 
 def test_squared_euclidean_same_neighbors_as_euclidean():


### PR DESCRIPTION
This is `NMSlibTransformer` maintenance.
- Unit tests (comparing euclidean & cosine distances of LegacyHNSW vs. NMSlibTransformer
- FEAT sparse matrix support in various `metric`s
- FIX LegacyHNSW cosine distances: previously returned cosine similarities (due to confusion of what `nmslib` calls `cosinesimil`, which is actually cosine distance)