### PR TITLE
Better KNeighborsTransformer compatibility; accuracy tests

### DIFF
--- a/skhubness/neighbors/_annoy.py
+++ b/skhubness/neighbors/_annoy.py
@@ -187,7 +187,7 @@ class AnnoyTransformer(BaseEstimator, TransformerMixin):
                 raise ValueError(f"Shape of X ({n_features} features) does not match "
                                  f"shape of fitted data ({self.n_features_in_} features.")
 
-        n_neighbors = self.n_neighbors
+        n_neighbors = self.n_neighbors + 1
 
         ind_dtype = np.int32 if self.n_samples_in_ <= np.iinfo(np.int32).max else np.int64
         dist_dtype = self.dtype_ if X is None else X.dtype

--- a/skhubness/neighbors/_ngt.py
+++ b/skhubness/neighbors/_ngt.py
@@ -251,6 +251,8 @@ class NGTTransformer(BaseEstimator, TransformerMixin):
         else:
             index = self.neighbor_index_
 
+        n_neighbors = self.n_neighbors + 1
+
         tqdm_fmt = partial(
             tqdm,
             desc="NGT transform",
@@ -263,7 +265,7 @@ class NGTTransformer(BaseEstimator, TransformerMixin):
         for i, query in enumerate(tqdm_fmt(X)):
             response = index.search(
                 query=query,
-                size=self.n_neighbors,
+                size=n_neighbors,
                 with_distance=True,
                 epsilon=self.epsilon,
             )
@@ -276,8 +278,8 @@ class NGTTransformer(BaseEstimator, TransformerMixin):
 
         indptr = np.arange(
             start=0,
-            stop=n_samples_transform * self.n_neighbors + 1,
-            step=self.n_neighbors,
+            stop=n_samples_transform * n_neighbors + 1,
+            step=n_neighbors,
         )
         kneighbors_graph = csr_matrix(
             (distances.ravel(), indices.ravel(), indptr),

--- a/skhubness/neighbors/_nmslib.py
+++ b/skhubness/neighbors/_nmslib.py
@@ -216,7 +216,6 @@ class NMSlibTransformer(BaseEstimator, TransformerMixin):
         self.n_jobs = n_jobs
         self.mmap_dir = mmap_dir
         self.verbose = verbose
-        self._do_sqrt = False
 
     def _construct_index_params_dict(self):
         if self.method in ["hnsw", "sw-graph"]:
@@ -349,7 +348,8 @@ class NMSlibTransformer(BaseEstimator, TransformerMixin):
 
         # nmslib MAY return squared distances (https://github.com/nmslib/nmslib/issues/504#issuecomment-949710037)
         # Let's do a little heuristic, if this is the case here, and sqrt if necessary.
-        if self.metric == "euclidean":
+        self._do_sqrt = False
+        if self.metric == "euclidean" and self.n_samples_in_ > 1:
             ((_, ind), (_, dist)) = index.knnQueryBatch(X[0:1, :], k=2)[0]
             sq_dist = np.sum(np.power(X[0, :] - X[ind, :], 2))
             if np.isclose(dist, sq_dist):

--- a/skhubness/neighbors/_puffinn.py
+++ b/skhubness/neighbors/_puffinn.py
@@ -170,6 +170,7 @@ class PuffinnTransformer(BaseEstimator, TransformerMixin):
                              f"shape of fitted data ({self.n_features_in_} features.")
 
         index = self.neighbor_index_
+        n_neighbors = self.n_neighbors + 1
 
         tqdm_fmt = partial(
             tqdm,
@@ -185,7 +186,7 @@ class PuffinnTransformer(BaseEstimator, TransformerMixin):
             # has at least `recall` chance of being found.
             ind = index.search(
                 vec=x.tolist(),
-                k=self.n_neighbors,
+                k=n_neighbors,
                 recall=self.recall,
             )
             ind = np.array(ind)
@@ -208,14 +209,6 @@ class PuffinnTransformer(BaseEstimator, TransformerMixin):
                 X_neigh_denormalized,
                 metric=PuffinnTransformer._sklearn_metric.get(self.metric),
             )
-            """
-            X_neigh_denormalized = X[ind] * self.X_indexed_norm_[ind].reshape(len(ind), -1)
-            distances[i, :] = pairwise_distances(
-                X[i:i+1, :] * self.X_indexed_norm_[i],
-                X_neigh_denormalized,
-                metric=self.metric,
-            )
-            """
 
         indptr = np.array([0, *np.cumsum([len(ind) for ind in indices])])
 

--- a/skhubness/neighbors/tests/test_annoy.py
+++ b/skhubness/neighbors/tests/test_annoy.py
@@ -153,15 +153,19 @@ def test_memory_mapped(mmap_dir, Annoy):
                                n_features=n_neighbors,
                                random_state=123,
                                )
+
+    n_neighbors_transformer = 5
+    n_neighbors_legacy = n_neighbors_transformer + 1
+
     if issubclass(Annoy, LegacyRandomProjectionTree):
         kwargs = {
             "mmap_dir": mmap_dir,
-            "n_candidates": n_neighbors,
+            "n_candidates": n_neighbors_legacy,
         }
     else:
         kwargs = {
             "mmap_dir": mmap_dir,
-            "n_neighbors": n_neighbors,
+            "n_neighbors": n_neighbors_transformer,
         }
     ann = Annoy(**kwargs)
     if isinstance(mmap_dir, str) or mmap_dir is None:
@@ -179,7 +183,7 @@ def test_memory_mapped(mmap_dir, Annoy):
             graph = ann.transform(X)
             assert sparse.issparse(graph)
             assert graph.shape == (n_samples, n_samples)
-            assert graph.nnz == n_neighbors * n_samples
+            assert graph.nnz == (n_neighbors_transformer + 1) * n_samples
             np.testing.assert_array_equal(graph.diagonal(), 0)
     else:
         with np.testing.assert_raises(TypeError):

--- a/skhubness/neighbors/tests/test_neighbors.py
+++ b/skhubness/neighbors/tests/test_neighbors.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 
 import numpy as np
@@ -15,6 +17,8 @@ from skhubness.neighbors import AnnoyTransformer, NGTTransformer, NMSlibTransfor
 @pytest.mark.parametrize("ApproximateNNTransformer",
                          [AnnoyTransformer, NGTTransformer, NMSlibTransformer, PuffinnTransformer])
 def test_ann_transformers_similar_to_exact_transformer(ApproximateNNTransformer, n_neighbors, metric):
+    if sys.platform == "win32" and issubclass(ApproximateNNTransformer, (NGTTransformer, PuffinnTransformer)):
+        pytest.skip(f"{ApproximateNNTransformer.__name__} is not available on Windows.")
     knn_metric = metric
     ann_metric = metric
     if issubclass(ApproximateNNTransformer, PuffinnTransformer) and metric in ["euclidean", "cosine"]:
@@ -64,4 +68,4 @@ def test_ann_transformers_similar_to_exact_transformer(ApproximateNNTransformer,
         np.testing.assert_array_almost_equal(ann_graph.data.ravel(), knn_graph.data.ravel())
     if issubclass(ApproximateNNTransformer, AnnoyTransformer) and metric == "cosine" and n_neighbors == 1:
         return  # Known inaccurate result
-    assert ann_acc > knn_acc or pytest.approx([ann_acc, knn_acc]), "ApproximateNN accuracy << exact kNN accuracy."
+    assert ann_acc > knn_acc or np.isclose(ann_acc, knn_acc), "ApproximateNN accuracy << exact kNN accuracy."

--- a/skhubness/neighbors/tests/test_neighbors.py
+++ b/skhubness/neighbors/tests/test_neighbors.py
@@ -1,0 +1,67 @@
+import pytest
+
+import numpy as np
+from scipy.sparse import csr_matrix
+from sklearn.datasets import make_classification
+from sklearn.metrics import accuracy_score
+from sklearn.model_selection import train_test_split
+from sklearn.neighbors import KNeighborsTransformer, KNeighborsClassifier
+
+from skhubness.neighbors import AnnoyTransformer, NGTTransformer, NMSlibTransformer, PuffinnTransformer
+
+
+@pytest.mark.parametrize("n_neighbors", [1, 5, 10])
+@pytest.mark.parametrize("metric", [None, "euclidean", "cosine"])
+@pytest.mark.parametrize("ApproximateNNTransformer",
+                         [AnnoyTransformer, NGTTransformer, NMSlibTransformer, PuffinnTransformer])
+def test_ann_transformers_similar_to_exact_transformer(ApproximateNNTransformer, n_neighbors, metric):
+    knn_metric = metric
+    ann_metric = metric
+    if issubclass(ApproximateNNTransformer, PuffinnTransformer) and metric in ["euclidean", "cosine"]:
+        pytest.skip(f"{ApproximateNNTransformer.__name__} does not support metric={metric}")
+    if issubclass(ApproximateNNTransformer, AnnoyTransformer) and metric == "cosine":
+        ann_metric = "angular"
+    n_samples = 100
+    X, y = make_classification(
+        n_samples=n_samples,
+        random_state=123,
+    )
+    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=456, shuffle=True, stratify=y)
+
+    # Exackt kNN graph for comparison
+    kwargs = {}
+    if knn_metric is not None:
+        kwargs["metric"] = knn_metric
+    knn = KNeighborsTransformer(n_neighbors=n_neighbors, **kwargs)
+    graph_train = knn.fit_transform(X_train, y_train)
+    knn_graph: csr_matrix = knn.transform(X_test)
+    knn_clf = KNeighborsClassifier(n_neighbors=n_neighbors, metric="precomputed")
+    y_pred_knn = knn_clf.fit(graph_train, y_train).predict(knn_graph)
+    knn_acc = accuracy_score(y_true=y_test, y_pred=y_pred_knn)
+
+    # ANN graph
+    kwargs = {}
+    if ann_metric is not None:
+        kwargs["metric"] = ann_metric
+    ann = ApproximateNNTransformer(n_neighbors=n_neighbors, **kwargs)
+    graph_train = ann.fit_transform(X_train, y_train)
+    ann_graph = ann.transform(X_test)
+    ann_clf = KNeighborsClassifier(n_neighbors=n_neighbors, metric="precomputed")
+    y_pred_ann = ann_clf.fit(graph_train, y_train).predict(ann_graph)
+    ann_acc = accuracy_score(y_true=y_test, y_pred=y_pred_ann)
+
+    # Neighbor graphs should be same class, same shape, same dtype
+    assert ann_graph.__class__ == knn_graph.__class__
+    assert ann_graph.shape == knn_graph.shape
+    assert ann_graph.dtype == knn_graph.dtype
+    assert ann_graph.nnz == knn_graph.nnz
+    if issubclass(ApproximateNNTransformer, AnnoyTransformer):
+        pass  # Known inaccuracy
+    elif issubclass(ApproximateNNTransformer, PuffinnTransformer) and metric is None:
+        pass  # Known inaccuracy
+    else:
+        np.testing.assert_array_equal(ann_graph.indices.ravel(), knn_graph.indices.ravel())
+        np.testing.assert_array_almost_equal(ann_graph.data.ravel(), knn_graph.data.ravel())
+    if issubclass(ApproximateNNTransformer, AnnoyTransformer) and metric == "cosine" and n_neighbors == 1:
+        return  # Known inaccurate result
+    assert ann_acc > knn_acc or pytest.approx([ann_acc, knn_acc]), "ApproximateNN accuracy << exact kNN accuracy."

--- a/skhubness/neighbors/tests/test_nmslib.py
+++ b/skhubness/neighbors/tests/test_nmslib.py
@@ -82,11 +82,17 @@ def test_transformer_vs_legacy_hnsw(metric):
     X_train, X_test = X[:split], X[split:]
     y_train, y_test = y[:split], y[split:]
 
-    hnsw = LegacyHNSW(metric=metric)
+    n_neigh_trafo = 5
+    n_neigh_legacy = n_neigh_trafo + 1
+
+    hnsw = LegacyHNSW(metric=metric, n_candidates=n_neigh_legacy)
     hnsw.fit(X_train, y_train)
     hnsw_neigh_dist, hnsw_neigh_ind = hnsw.kneighbors(X_test, return_distance=True)
+    # HNSW returns squared distances in this case. Atm, I don't want to change this in LegacyHNSW.
+    if metric == "euclidean":
+        np.sqrt(hnsw_neigh_dist, out=hnsw_neigh_dist)
 
-    nms = NMSlibTransformer(metric=metric)
+    nms = NMSlibTransformer(metric=metric, n_neighbors=n_neigh_trafo)
     nms.fit(X_train, y_train)
     nms_graph = nms.transform(X_test)
 

--- a/skhubness/neighbors/tests/test_nmslib.py
+++ b/skhubness/neighbors/tests/test_nmslib.py
@@ -113,7 +113,9 @@ def test_all_metrics(metric, dtype):
         if convert_to_str:
             X = matrix_to_str_array(X)
     else:
-        X = np.random.rand(n, m).astype(dtype)
+        X = np.random.rand(n, m)
+        X *= 10.
+        X = X.astype(dtype)
     nms = NMSlibTransformer(metric=metric, **kwargs)
     graph = nms.fit_transform(X)
     assert graph.shape == (20, 20)

--- a/skhubness/neighbors/tests/test_puffinn.py
+++ b/skhubness/neighbors/tests/test_puffinn.py
@@ -156,12 +156,14 @@ def test_transformer_vs_legacy_puffinn(metric):
     X_train, X_test = X[:split], X[split:]
     y_train, y_test = y[:split], y[split:]
 
+    n_neigh_trafo = 5
+    n_neigh_legacy = n_neigh_trafo + 1
     memory = 20_000_000 + np.multiply(*X.shape) * 8 if metric == "jaccard" else None
-    legacy_puffinn = LegacyPuffinn(metric=metric, memory=memory)
+    legacy_puffinn = LegacyPuffinn(metric=metric, n_candidates=n_neigh_legacy, memory=memory)
     legacy_puffinn.fit(X_train, y_train)
     hnsw_neigh_dist, hnsw_neigh_ind = legacy_puffinn.kneighbors(X_test, return_distance=True)
 
-    puffinn_trafo = PuffinnTransformer(metric=metric, memory=memory)
+    puffinn_trafo = PuffinnTransformer(metric=metric, n_neighbors=n_neigh_trafo, memory=memory)
     puffinn_trafo.fit(X_train, y_train)
     nms_graph = puffinn_trafo.transform(X_test)
 


### PR DESCRIPTION
This makes approximate nearest neighbor Transformers (AnnoyTransformer, NMSlibTransformer, etc.) more compliant with sklearn's `KNeighborsTransformer` behavior: One more neighbor than asked for is retrieved in order to handle self neighbor cases.

Also introduces accuracy tests for all Transformers.